### PR TITLE
Stripping binary post-build

### DIFF
--- a/cmake/CurrentPlatform.cmake
+++ b/cmake/CurrentPlatform.cmake
@@ -29,6 +29,13 @@ macro(spelunky_psp_add_platform_dependencies)
 endmacro()
 
 macro(spelunky_psp_post_build)
+    add_custom_command(
+        TARGET Spelunky_PSP
+        POST_BUILD COMMAND
+        "psp-strip" "$<TARGET_FILE:Spelunky_PSP>"
+        COMMENT "Stripping binary"
+    )
+
     if (${SPELUNKY_PSP_PLATFORM} STREQUAL PSP)
         create_pbp_file(TARGET Spelunky_PSP
             ICON_PATH ${ASSETS_PATH}/metadata/icon.png


### PR DESCRIPTION
Before:

```shell
dbeef@dbeefstation:~/spelunky-psp$ ls -sh ./tmp/build-psp/EBOOT.PBP
11M ./tmp/build-psp/EBOOT.PBP
```

After:

```shell
dbeef@dbeefstation:~/spelunky-psp$  ls -sh ./tmp/build-psp/EBOOT.PBP
1.6M ./tmp/build-psp/EBOOT.PBP
```