### PR TITLE
Fixed binaries' install path, cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ jobs:
     name: "Build PSP"
     script:
       - docker exec -w $WORKDIR $_C /bin/bash -c "./scripts/config-psp.sh ; ./scripts/build-psp.sh"
-      - cp tmp/build-psp/SpelunkyPSP.PBP install/SpelunkyPSP.pbp
+      - cp tmp/build-psp/EBOOT.PBP install/SpelunkyPSP.pbp
   - name: "Build Linux"
     script:
       - docker exec -w $WORKDIR $_C /bin/bash -c "./scripts/config-linux.sh ; ./scripts/build-linux.sh"

--- a/cmake/CurrentPlatform.cmake
+++ b/cmake/CurrentPlatform.cmake
@@ -29,14 +29,14 @@ macro(spelunky_psp_add_platform_dependencies)
 endmacro()
 
 macro(spelunky_psp_post_build)
-    add_custom_command(
-        TARGET Spelunky_PSP
-        POST_BUILD COMMAND
-        "psp-strip" "$<TARGET_FILE:Spelunky_PSP>"
-        COMMENT "Stripping binary"
-    )
-
     if (${SPELUNKY_PSP_PLATFORM} STREQUAL PSP)
+        add_custom_command(
+            TARGET Spelunky_PSP
+            POST_BUILD COMMAND
+            "psp-strip" "$<TARGET_FILE:Spelunky_PSP>"
+            COMMENT "Stripping binary"
+        )
+
         create_pbp_file(TARGET Spelunky_PSP
             ICON_PATH ${ASSETS_PATH}/metadata/icon.png
             BACKGROUND_PATH ${ASSETS_PATH}/metadata/background.png

--- a/vendor/cjson/CMakeLists.txt
+++ b/vendor/cjson/CMakeLists.txt
@@ -143,9 +143,9 @@ endif()
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/library_config/libcjson.pc.in"
     "${CMAKE_CURRENT_BINARY_DIR}/libcjson.pc" @ONLY)
 
-install(FILES cJSON.h DESTINATION "${CMAKE_INSTALL_FULL_INCLUDEDIR}/cjson")
-install (FILES "${CMAKE_CURRENT_BINARY_DIR}/libcjson.pc" DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig")
-install(TARGETS "${CJSON_LIB}" DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}" EXPORT "${CJSON_LIB}")
+# install(FILES cJSON.h DESTINATION "${CMAKE_INSTALL_FULL_INCLUDEDIR}/cjson")
+# install (FILES "${CMAKE_CURRENT_BINARY_DIR}/libcjson.pc" DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig")
+# install(TARGETS "${CJSON_LIB}" DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}" EXPORT "${CJSON_LIB}")
 if (BUILD_SHARED_AND_STATIC_LIBS)
     install(TARGETS "${CJSON_LIB}-static" DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}")
 endif()
@@ -182,12 +182,12 @@ if(ENABLE_CJSON_UTILS)
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/library_config/libcjson_utils.pc.in"
         "${CMAKE_CURRENT_BINARY_DIR}/libcjson_utils.pc" @ONLY)
 
-    install(TARGETS "${CJSON_UTILS_LIB}" DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}" EXPORT "${CJSON_UTILS_LIB}")
+    # install(TARGETS "${CJSON_UTILS_LIB}" DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}" EXPORT "${CJSON_UTILS_LIB}")
     if (BUILD_SHARED_AND_STATIC_LIBS)
         install(TARGETS "${CJSON_UTILS_LIB}-static" DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}")
     endif()
-    install(FILES cJSON_Utils.h DESTINATION "${CMAKE_INSTALL_FULL_INCLUDEDIR}/cjson")
-    install (FILES "${CMAKE_CURRENT_BINARY_DIR}/libcjson_utils.pc" DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig")
+    # install(FILES cJSON_Utils.h DESTINATION "${CMAKE_INSTALL_FULL_INCLUDEDIR}/cjson")
+    # install (FILES "${CMAKE_CURRENT_BINARY_DIR}/libcjson_utils.pc" DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig")
     if(ENABLE_TARGET_EXPORT)
       # export library information for CMake projects
       install(EXPORT "${CJSON_UTILS_LIB}" DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/cmake/cJSON")
@@ -200,17 +200,17 @@ if(ENABLE_CJSON_UTILS)
 endif()
 
 # create the other package config files
-configure_file(
-    "${CMAKE_CURRENT_SOURCE_DIR}/library_config/cJSONConfig.cmake.in"
-    ${PROJECT_BINARY_DIR}/cJSONConfig.cmake @ONLY)
-configure_file(
-    "${CMAKE_CURRENT_SOURCE_DIR}/library_config/cJSONConfigVersion.cmake.in"
-    ${PROJECT_BINARY_DIR}/cJSONConfigVersion.cmake @ONLY)
+# configure_file(
+#     "${CMAKE_CURRENT_SOURCE_DIR}/library_config/cJSONConfig.cmake.in"
+#     ${PROJECT_BINARY_DIR}/cJSONConfig.cmake @ONLY)
+# configure_file(
+#     "${CMAKE_CURRENT_SOURCE_DIR}/library_config/cJSONConfigVersion.cmake.in"
+#     ${PROJECT_BINARY_DIR}/cJSONConfigVersion.cmake @ONLY)
 
 # Install package config files
-install(FILES ${PROJECT_BINARY_DIR}/cJSONConfig.cmake
-    ${PROJECT_BINARY_DIR}/cJSONConfigVersion.cmake
-    DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/cmake/cJSON")
+# install(FILES ${PROJECT_BINARY_DIR}/cJSONConfig.cmake
+#     ${PROJECT_BINARY_DIR}/cJSONConfigVersion.cmake
+#     DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/cmake/cJSON")
 
 # Enable the use of locales
 option(ENABLE_LOCALES "Enable the use of locales" ON)


### PR DESCRIPTION
Hi!

Apart from fixing install paths (tsk, tsk) and running the PSP artifact through `psp-strip` only, additionally `cJSON` is no longer installed by `CMake`.

Best
Rafal