### PR TITLE
Camera following MainDude when out of a bounding box

### DIFF
--- a/src/camera/interface/Camera.hpp
+++ b/src/camera/interface/Camera.hpp
@@ -1,14 +1,13 @@
 #pragma once
 
-#include <cstdint>
-
 class Camera
 {
 public:
 
     void update_gl_modelview_matrix();
     void update_gl_projection_matrix() const;
-
+    Camera(Camera&) = delete;
+    Camera(Camera&&) = delete;
     static Camera& instance();
     static void init();
     static void dispose();
@@ -19,12 +18,19 @@ public:
     inline void setX(float x) { _dirty = true; _x = x; }
     inline void setY(float y) { _dirty = true; _y = y; }
 
+    void adjust_to_bounding_box(float x, float y);
 private:
+    explicit Camera();
 
     bool _dirty = false;
 
     float _x = 0;
     float _y = 0;
+    
+    const float _bounding_x;
+    const float _bounding_y;
+    const float _bounding_x_half;
+    const float _bounding_y_half;
 
     static Camera* _camera;
 };

--- a/src/camera/src/Camera.cpp
+++ b/src/camera/src/Camera.cpp
@@ -50,7 +50,12 @@ void Camera::update_gl_modelview_matrix()
 {
     if (_dirty)
     {
-        graphics_utils::look_at(_x, _y);
+        // rounding the values to 1 decimal point
+        // to avoid vertical screen-tearing like artifacts
+        auto rounded_x = (10.f * _x + .5f) / 10;
+        auto rounded_y = (10.f * _y + .5f) / 10;
+
+        graphics_utils::look_at(rounded_x, rounded_y);
         _dirty = false;
     }
 }

--- a/src/camera/src/Camera.cpp
+++ b/src/camera/src/Camera.cpp
@@ -20,6 +20,13 @@ namespace
 
 Camera *Camera::_camera = nullptr;
 
+Camera::Camera()
+    : _bounding_x(2.f)
+    , _bounding_y(1.3f)
+    , _bounding_x_half(_bounding_x / 2)
+    , _bounding_y_half(_bounding_y / 2)
+{ }
+
 Camera &Camera::instance()
 {
     assert(_camera);
@@ -51,8 +58,7 @@ void Camera::update_gl_modelview_matrix()
 void Camera::update_gl_projection_matrix() const
 {
     const auto& video = Video::instance();
-
-    DebugGlCall(glViewport(0, 0, (float) (video.get_window_width()), (float) (video.get_window_height())));
+    DebugGlCall(glViewport(0, 0, (GLsizei) (video.get_window_width()), (GLsizei) (video.get_window_height())));
     DebugGlCall(glMatrixMode(GL_PROJECTION));
     DebugGlCall(glLoadIdentity());
 
@@ -66,4 +72,22 @@ void Camera::update_gl_projection_matrix() const
                         -1 * coeff,
                          near,
                          far));
+}
+
+void Camera::adjust_to_bounding_box(float x, float y)
+{
+    auto dx = (x / 2) - _x;
+    auto dy = (y / 2) - _y;
+
+    if (std::abs(dx) > _bounding_x_half)
+    {
+        _x+= dx + (dx > 0.f ? -_bounding_x_half : _bounding_x_half);
+        _dirty = true;
+    }
+    
+    if (std::abs(dy) > _bounding_y_half)
+    {
+        _y+= dy + (dy > 0.f ? -_bounding_y_half : _bounding_y_half);
+        _dirty = true;
+    }
 }

--- a/src/game-loop/CMakeLists.txt
+++ b/src/game-loop/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(GameLoop STATIC
         src/main-dude/states/MainDudeJumpingState.cpp
         src/components/PhysicsComponent.cpp
         src/components/QuadComponent.cpp
+        src/components/CameraComponent.cpp
         src/components/AnimationComponent.cpp
         interface/GameLoop.hpp
         interface/GameState.hpp
@@ -22,6 +23,7 @@ add_library(GameLoop STATIC
         include/components/PhysicsComponent.hpp
         include/components/QuadComponent.hpp
         include/components/AnimationComponent.hpp
+        include/components/CameraComponent.hpp
         include/main-dude/MainDudeSpritesheetFrames.hpp
         include/main-dude/states/MainDudeBaseState.hpp
         include/main-dude/states/MainDudeRunningState.hpp

--- a/src/game-loop/include/components/CameraComponent.hpp
+++ b/src/game-loop/include/components/CameraComponent.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <cstdint>
+
+class MainDude;
+
+class CameraComponent
+{
+public:
+    void update(const MainDude&, uint32_t delta_time_ms);
+};

--- a/src/game-loop/include/main-dude/MainDude.hpp
+++ b/src/game-loop/include/main-dude/MainDude.hpp
@@ -7,6 +7,7 @@
 #include "components/PhysicsComponent.hpp"
 #include "components/QuadComponent.hpp"
 #include "components/AnimationComponent.hpp"
+#include "components/CameraComponent.hpp"
 
 #include "main-dude/states/MainDudeRunningState.hpp"
 #include "main-dude/states/MainDudeExitingState.hpp"
@@ -38,9 +39,11 @@ private:
     friend class PhysicsComponent;
     friend class QuadComponent;
     friend class AnimationComponent;
+    friend class CameraComponent;
     PhysicsComponent _physics;
     QuadComponent _quad;
     AnimationComponent _animation;
+    CameraComponent _camera;
 
     friend class MainDudeBaseState;
     friend class MainDudeRunningState;

--- a/src/game-loop/src/GameLoop.cpp
+++ b/src/game-loop/src/GameLoop.cpp
@@ -15,32 +15,6 @@
 
 #include <algorithm>
 
-namespace
-{
-    void handle_input()
-    {
-        const auto& input = Input::instance();
-        Camera& camera = Camera::instance();
-
-        if (input.left())
-        {
-            camera.setX(camera.getX() - 0.1f);
-        }
-        if (input.right())
-        {
-            camera.setX(camera.getX() + 0.1f);
-        }
-        if (input.up())
-        {
-            camera.setY(camera.getY() - 0.1f);
-        }
-        if (input.down())
-        {
-            camera.setY(camera.getY() + 0.1f);
-        }
-    }
-}
-
 std::function<void(uint32_t delta_time_ms)>& GameLoop::get()
 {
     return _loop;
@@ -90,7 +64,5 @@ GameLoop::GameLoop()
         {
             _game_objects.erase(it, _game_objects.end());
         }
-
-        handle_input();
     };
 }

--- a/src/game-loop/src/components/CameraComponent.cpp
+++ b/src/game-loop/src/components/CameraComponent.cpp
@@ -1,0 +1,16 @@
+#include "components/CameraComponent.hpp"
+
+#include "main-dude/MainDude.hpp"
+#include "Camera.hpp"
+
+#include <cmath>
+#include <logger/log.h>
+
+void CameraComponent::update(const MainDude& dude, uint32_t delta_time_ms)
+{
+    auto x = dude._physics.get_x_position();
+    auto y = dude._physics.get_y_position();
+
+    auto& camera = Camera::instance();
+    camera.adjust_to_bounding_box(x, y);
+}

--- a/src/game-loop/src/main-dude/states/MainDudeCrawlingState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeCrawlingState.cpp
@@ -16,6 +16,7 @@ MainDudeBaseState* MainDudeCrawlingState::update(MainDude& main_dude, uint32_t d
 
     main_dude._physics.update(main_dude, delta_time_ms);
     main_dude._quad.update(main_dude, delta_time_ms);
+    main_dude._camera.update(main_dude, delta_time_ms);
     main_dude._animation.update(main_dude, delta_time_ms);
 
     // Other:

--- a/src/game-loop/src/main-dude/states/MainDudeCrawlingState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeCrawlingState.cpp
@@ -40,15 +40,15 @@ MainDudeBaseState* MainDudeCrawlingState::update(MainDude& main_dude, uint32_t d
 
 MainDudeBaseState *MainDudeCrawlingState::handle_input(MainDude& main_dude, const Input &input)
 {
-    if (input.square())
+    if (input.left())
     {
         main_dude._physics.add_velocity(-MainDude::CRAWLING_DELTA_X, 0.0f);
     }
-    if (input.circle())
+    if (input.right())
     {
         main_dude._physics.add_velocity(MainDude::CRAWLING_DELTA_X, 0.0f);
     }
-    if (input.triangle())
+    if (input.circle())
     {
         main_dude._physics.add_velocity(0.0f, -MainDude::JUMP_SPEED);
         return &main_dude._states.jumping;
@@ -63,7 +63,7 @@ MainDudeBaseState *MainDudeCrawlingState::handle_input(MainDude& main_dude, cons
         return &main_dude._states.throwing;
     }
 
-    if (input.bumper_l()) // FIXME: Awkward key mapping, change once camera following is implemented
+    if (input.up())
     {
         const auto* exit_tile = main_dude.is_overlaping_exit();
         if (exit_tile)

--- a/src/game-loop/src/main-dude/states/MainDudeDuckingState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeDuckingState.cpp
@@ -14,6 +14,7 @@ MainDudeBaseState* MainDudeDuckingState::update(MainDude& main_dude, uint32_t de
 
     main_dude._physics.update(main_dude, delta_time_ms);
     main_dude._quad.update(main_dude, delta_time_ms);
+    main_dude._camera.update(main_dude, delta_time_ms);
 
     // Other:
 

--- a/src/game-loop/src/main-dude/states/MainDudeDuckingState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeDuckingState.cpp
@@ -37,17 +37,17 @@ MainDudeBaseState* MainDudeDuckingState::update(MainDude& main_dude, uint32_t de
 
 MainDudeBaseState *MainDudeDuckingState::handle_input(MainDude& main_dude, const Input &input)
 {
-    if (input.square())
+    if (input.left())
     {
         main_dude._physics.add_velocity(-MainDude::DEFAULT_DELTA_X, 0.0f);
         return &main_dude._states.crawling;
     }
-    if (input.circle())
+    if (input.right())
     {
         main_dude._physics.add_velocity(MainDude::DEFAULT_DELTA_X, 0.0f);
         return &main_dude._states.crawling;
     }
-    if (input.triangle())
+    if (input.circle())
     {
         main_dude._physics.add_velocity(0.0f, -MainDude::JUMP_SPEED);
         return &main_dude._states.jumping;
@@ -62,7 +62,7 @@ MainDudeBaseState *MainDudeDuckingState::handle_input(MainDude& main_dude, const
         return &main_dude._states.throwing;
     }
 
-    if (input.bumper_l()) // FIXME: Awkward key mapping, change once camera following is implemented
+    if (input.up())
     {
         const auto* exit_tile = main_dude.is_overlaping_exit();
         if (exit_tile)

--- a/src/game-loop/src/main-dude/states/MainDudeExitingState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeExitingState.cpp
@@ -13,6 +13,7 @@ MainDudeBaseState* MainDudeExitingState::update(MainDude& main_dude, uint32_t de
 {
     main_dude._animation.update(main_dude, delta_time_ms);
     main_dude._quad.update(main_dude, delta_time_ms);
+    main_dude._camera.update(main_dude, delta_time_ms);
 
     if (main_dude._animation.is_finished())
     {

--- a/src/game-loop/src/main-dude/states/MainDudeFallingState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeFallingState.cpp
@@ -15,6 +15,7 @@ MainDudeBaseState* MainDudeFallingState::update(MainDude& main_dude, uint32_t de
 
     main_dude._physics.update(main_dude, delta_time_ms);
     main_dude._quad.update(main_dude, delta_time_ms);
+    main_dude._camera.update(main_dude, delta_time_ms);
 
     // Other:
 

--- a/src/game-loop/src/main-dude/states/MainDudeFallingState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeFallingState.cpp
@@ -36,11 +36,11 @@ MainDudeBaseState* MainDudeFallingState::update(MainDude& main_dude, uint32_t de
 
 MainDudeBaseState *MainDudeFallingState::handle_input(MainDude& main_dude, const Input &input)
 {
-    if (input.square())
+    if (input.left())
     {
         main_dude._physics.add_velocity(-MainDude::DEFAULT_DELTA_X, 0.0f);
     }
-    if (input.circle())
+    if (input.right())
     {
         main_dude._physics.add_velocity(MainDude::DEFAULT_DELTA_X, 0.0f);
     }
@@ -61,7 +61,7 @@ MainDudeBaseState *MainDudeFallingState::handle_input(MainDude& main_dude, const
         return &main_dude._states.throwing;
     }
 
-    if (input.bumper_l()) // FIXME: Awkward key mapping, change once camera following is implemented
+    if (input.up())
     {
         const auto* exit_tile = main_dude.is_overlaping_exit();
         if (exit_tile)

--- a/src/game-loop/src/main-dude/states/MainDudeJumpingState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeJumpingState.cpp
@@ -15,6 +15,7 @@ MainDudeBaseState* MainDudeJumpingState::update(MainDude& main_dude, uint32_t de
 
     main_dude._physics.update(main_dude, delta_time_ms);
     main_dude._quad.update(main_dude, delta_time_ms);
+    main_dude._camera.update(main_dude, delta_time_ms);
 
     // Other:
 

--- a/src/game-loop/src/main-dude/states/MainDudeJumpingState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeJumpingState.cpp
@@ -36,11 +36,11 @@ MainDudeBaseState* MainDudeJumpingState::update(MainDude& main_dude, uint32_t de
 
 MainDudeBaseState *MainDudeJumpingState::handle_input(MainDude& main_dude, const Input &input)
 {
-    if (input.square())
+    if (input.left())
     {
         main_dude._physics.add_velocity(-MainDude::DEFAULT_DELTA_X, 0.0f);
     }
-    if (input.circle())
+    if (input.right())
     {
         main_dude._physics.add_velocity(MainDude::DEFAULT_DELTA_X, 0.0f);
     }
@@ -61,7 +61,7 @@ MainDudeBaseState *MainDudeJumpingState::handle_input(MainDude& main_dude, const
         return &main_dude._states.throwing;
     }
 
-    if (input.bumper_l()) // FIXME: Awkward key mapping, change once camera following is implemented
+    if (input.up())
     {
         const auto* exit_tile = main_dude.is_overlaping_exit();
         if (exit_tile)

--- a/src/game-loop/src/main-dude/states/MainDudePushingState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudePushingState.cpp
@@ -37,7 +37,7 @@ MainDudeBaseState* MainDudePushingState::update(MainDude& main_dude, uint32_t de
 
 MainDudeBaseState *MainDudePushingState::handle_input(MainDude& main_dude, const Input &input)
 {
-    if (input.square())
+    if (input.left())
     {
         main_dude._physics.add_velocity(-MainDude::DEFAULT_DELTA_X, 0.0f);
     }
@@ -46,7 +46,7 @@ MainDudeBaseState *MainDudePushingState::handle_input(MainDude& main_dude, const
         return &main_dude._states.running;
     }
 
-    if (input.circle())
+    if (input.right())
     {
         main_dude._physics.add_velocity(MainDude::DEFAULT_DELTA_X, 0.0f);
     }
@@ -55,7 +55,7 @@ MainDudeBaseState *MainDudePushingState::handle_input(MainDude& main_dude, const
         return &main_dude._states.running;
     }
 
-    if (input.triangle())
+    if (input.circle())
     {
         main_dude._physics.add_velocity(0.0f, -MainDude::JUMP_SPEED);
         return &main_dude._states.jumping;

--- a/src/game-loop/src/main-dude/states/MainDudePushingState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudePushingState.cpp
@@ -15,6 +15,7 @@ MainDudeBaseState* MainDudePushingState::update(MainDude& main_dude, uint32_t de
 
     main_dude._physics.update(main_dude, delta_time_ms);
     main_dude._quad.update(main_dude, delta_time_ms);
+    main_dude._camera.update(main_dude, delta_time_ms);
     main_dude._animation.update(main_dude, delta_time_ms);
 
     // Other:

--- a/src/game-loop/src/main-dude/states/MainDudeRunningState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeRunningState.cpp
@@ -16,6 +16,7 @@ MainDudeBaseState *MainDudeRunningState::update(MainDude& main_dude, uint32_t de
 
     main_dude._physics.update(main_dude, delta_time_ms);
     main_dude._quad.update(main_dude, delta_time_ms);
+    main_dude._camera.update(main_dude, delta_time_ms);
     main_dude._animation.update(main_dude, delta_time_ms);
 
     // Other:

--- a/src/game-loop/src/main-dude/states/MainDudeRunningState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeRunningState.cpp
@@ -40,15 +40,15 @@ MainDudeBaseState *MainDudeRunningState::update(MainDude& main_dude, uint32_t de
 
 MainDudeBaseState *MainDudeRunningState::handle_input(MainDude& main_dude, const Input &input)
 {
-    if (input.square())
+    if (input.left())
     {
         main_dude._physics.add_velocity(-MainDude::DEFAULT_DELTA_X, 0.0f);
     }
-    if (input.circle())
+    if (input.right())
     {
         main_dude._physics.add_velocity(MainDude::DEFAULT_DELTA_X, 0.0f);
     }
-    if (input.triangle())
+    if (input.circle())
     {
         main_dude._physics.add_velocity(0.0f, -MainDude::JUMP_SPEED);
         return &main_dude._states.jumping;
@@ -74,7 +74,7 @@ MainDudeBaseState *MainDudeRunningState::handle_input(MainDude& main_dude, const
         return &main_dude._states.throwing;
     }
 
-    if (input.bumper_l()) // FIXME: Awkward key mapping, change once camera following is implemented
+    if (input.up())
     {
         const auto* exit_tile = main_dude.is_overlaping_exit();
         if (exit_tile)

--- a/src/game-loop/src/main-dude/states/MainDudeStandingState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeStandingState.cpp
@@ -52,15 +52,15 @@ MainDudeBaseState *MainDudeStandingState::update(MainDude& main_dude, uint32_t d
 
 MainDudeBaseState *MainDudeStandingState::handle_input(MainDude& main_dude, const Input &input)
 {
-    if (input.square())
+    if (input.left())
     {
         main_dude._physics.add_velocity(-MainDude::DEFAULT_DELTA_X, 0.0f);
     }
-    if (input.circle())
+    if (input.right())
     {
         main_dude._physics.add_velocity(MainDude::DEFAULT_DELTA_X, 0.0f);
     }
-    if (input.triangle())
+    if (input.circle())
     {
         main_dude._physics.add_velocity(0.0f, -MainDude::JUMP_SPEED);
         return &main_dude._states.jumping;
@@ -74,7 +74,7 @@ MainDudeBaseState *MainDudeStandingState::handle_input(MainDude& main_dude, cons
         return &main_dude._states.throwing;
     }
 
-    if (input.bumper_l()) // FIXME: Awkward key mapping, change once camera following is implemented
+    if (input.up())
     {
         const auto* exit_tile = main_dude.is_overlaping_exit();
         if (exit_tile)

--- a/src/game-loop/src/main-dude/states/MainDudeStandingState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeStandingState.cpp
@@ -15,6 +15,7 @@ MainDudeBaseState *MainDudeStandingState::update(MainDude& main_dude, uint32_t d
 
     main_dude._physics.update(main_dude, delta_time_ms);
     main_dude._quad.update(main_dude, delta_time_ms);
+    main_dude._camera.update(main_dude, delta_time_ms);
 
     // Other:
 

--- a/src/game-loop/src/main-dude/states/MainDudeThrowingState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeThrowingState.cpp
@@ -51,11 +51,11 @@ MainDudeBaseState *MainDudeThrowingState::update(MainDude& main_dude, uint32_t d
 
 MainDudeBaseState *MainDudeThrowingState::handle_input(MainDude& main_dude, const Input &input)
 {
-    if (input.square())
+    if (input.left())
     {
         main_dude._physics.add_velocity(-MainDude::DEFAULT_DELTA_X, 0.0f);
     }
-    if (input.circle())
+    if (input.right())
     {
         main_dude._physics.add_velocity(MainDude::DEFAULT_DELTA_X, 0.0f);
     }

--- a/src/game-loop/src/main-dude/states/MainDudeThrowingState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeThrowingState.cpp
@@ -15,6 +15,7 @@ MainDudeBaseState *MainDudeThrowingState::update(MainDude& main_dude, uint32_t d
 
     main_dude._physics.update(main_dude, delta_time_ms);
     main_dude._quad.update(main_dude, delta_time_ms);
+    main_dude._camera.update(main_dude, delta_time_ms);
     main_dude._animation.update(main_dude, delta_time_ms);
 
     // Other:


### PR DESCRIPTION
What I'd like to see in this PR:
* [x] adjust the bounding box to behave like in the original game
* [x] controls' remap, to take into account the fact camera is now bound to a moving object

Stopping the camera at level's border might require small refactoring.

EDIT: I'll drop the topics for now, let's not do too much.