### PR TITLE
Fixing 3rdparty tools issues on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ include(cmake/CurrentPlatform.cmake)
 spelunky_psp_detect_platform()
 spelunky_psp_add_platform_dependencies()
 
-if (SPELUNKY_PSP_PLATFORM_LINUX)
+if (SPELUNKY_PSP_PLATFORM_DESKTOP)
     # Tools meant to be run only on host (development) system.
     add_subdirectory(tools)
 endif()

--- a/tools/resource_compiler/src/Main.cpp
+++ b/tools/resource_compiler/src/Main.cpp
@@ -6,6 +6,7 @@
 #include <fstream>
 #include <sstream>
 #include <chrono>
+#include <ctime>
 
 namespace
 {

--- a/tools/texture_packer/3rdparty/sx/CMakeLists.txt
+++ b/tools/texture_packer/3rdparty/sx/CMakeLists.txt
@@ -152,6 +152,8 @@ endif()
 if (SX_SHARED_LIB)
     add_definitions(-DSX_CONFIG_SHARED_LIB=1)
     set(LIB_TYPE SHARED)
+else()
+    set(LIB_TYPE STATIC)
 endif()
 
 add_library(sx ${LIB_TYPE} ${SOURCE_FILES} ${INCLUDE_FILES} ${ASM_SOURCES})


### PR DESCRIPTION
Howdy! During my -- albeit failed -- attempt to bring the resource compiler closer to CMake, I found the following issues building the third-party tools on Windows.

I am temporarily dropping the topic of a resource compiler callable from CMake, as this would require a broader discussion around cross-compilation.