### PR TITLE
Bugfix for duplicating level render entities.

### DIFF
--- a/src/game-loop/src/game-loop/GameLoopLevelSummaryState.cpp
+++ b/src/game-loop/src/game-loop/GameLoopLevelSummaryState.cpp
@@ -62,7 +62,6 @@ void GameLoopLevelSummaryState::enter(GameLoop& game_loop)
     LevelGenerator::instance().getLevel().initialise_tiles_from_splash_screen(SplashScreenType::LEVEL_SUMMARY);
     LevelGenerator::instance().getLevel().generate_cave_background();
     LevelGenerator::instance().getLevel().batch_vertices();
-    LevelGenerator::instance().getLevel().add_render_entity();
 
     auto &camera = Camera::instance();
     camera.set_x_not_rounded(5.0f);

--- a/src/game-loop/src/game-loop/GameLoopMainMenuState.cpp
+++ b/src/game-loop/src/game-loop/GameLoopMainMenuState.cpp
@@ -62,7 +62,6 @@ void GameLoopMainMenuState::enter(GameLoop& game_loop)
     LevelGenerator::instance().getLevel().initialise_tiles_from_splash_screen(SplashScreenType::MAIN_MENU);
     LevelGenerator::instance().getLevel().generate_cave_background();
     LevelGenerator::instance().getLevel().batch_vertices();
-    LevelGenerator::instance().getLevel().add_render_entity();
 
     auto &camera = Camera::instance();
     camera.set_x_not_rounded(5.0f);

--- a/src/game-loop/src/game-loop/GameLoopPlayingState.cpp
+++ b/src/game-loop/src/game-loop/GameLoopPlayingState.cpp
@@ -65,7 +65,6 @@ void GameLoopPlayingState::enter(GameLoop& game_loop)
     LevelGenerator::instance().getLevel().generate_frame();
     LevelGenerator::instance().getLevel().generate_cave_background();
     LevelGenerator::instance().getLevel().batch_vertices();
-    LevelGenerator::instance().getLevel().add_render_entity();
 
     game_loop._main_dude = std::make_shared<MainDude>(0, 0);
     game_loop._game_objects.push_back(game_loop._main_dude);

--- a/src/game-loop/src/game-loop/GameLoopStartedState.cpp
+++ b/src/game-loop/src/game-loop/GameLoopStartedState.cpp
@@ -1,3 +1,4 @@
+#include "LevelGenerator.hpp"
 #include "logger/log.h"
 #include "GameLoopStartedState.hpp"
 #include "Camera.hpp"
@@ -27,6 +28,11 @@ void GameLoopStartedState::enter(GameLoop &)
 
     Camera::instance().calculate_coefficients();
     Camera::instance().update_gl_projection_matrix();
+
+    LevelGenerator::instance().getLevel().clean_map_layout();
+    LevelGenerator::instance().getLevel().generate_cave_background();
+    LevelGenerator::instance().getLevel().batch_vertices();
+    LevelGenerator::instance().getLevel().add_render_entity();
 
     _game_initialized = true;
 }


### PR DESCRIPTION
Level render entities were added every time when level was re-generated, but not disposed, resulting
on levels being rendered on top of each other.

Manifested as FPS drastically dropping on hardware-constrained platforms like PSP.
