### PR TITLE
Decoupling Viewport from Video Context

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ set(ASSETS_PATH ${CMAKE_CURRENT_SOURCE_DIR}/assets)
 add_executable(Spelunky_PSP src/Main.cpp)
 
 add_subdirectory(vendor)
+add_subdirectory(src/viewport)
 add_subdirectory(src/video)
 add_subdirectory(src/level-generator)
 add_subdirectory(src/renderer)

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -14,12 +14,10 @@ void init_singletons()
     Renderer::init();
     TextureBank::init();
     Input::init();
-    Video::init();
 }
 
 void dispose_singletons()
 {
-    Video::dispose();
     LevelGenerator::dispose();
     TextureBank::dispose();
     Renderer::dispose();
@@ -30,18 +28,20 @@ int start()
     log_info("Started.");
     init_singletons();
 
-    if (!Video::instance().setup_gl())
+    Video video;
+
+    if (!video.setup_gl())
     {
         log_error("Failed to setup OpenGL.");
         return EXIT_FAILURE;
     }
 
     {
-        GameLoop loop;
-        Video::instance().run_loop(loop.get());
+        GameLoop loop(video.get_viewport());
+        video.run_loop(loop.get());
     }
 
-    Video::instance().tear_down_gl();
+    video.tear_down_gl();
 
     dispose_singletons();
     log_info("Exiting peacefully.");

--- a/src/camera/CMakeLists.txt
+++ b/src/camera/CMakeLists.txt
@@ -1,20 +1,27 @@
 project(Camera)
 
 add_library(Camera STATIC
-        src/ModelViewCamera.cpp
-        src/ScreenSpaceCamera.cpp
-        interface/ModelViewCamera.hpp
-        interface/ScreenSpaceCamera.hpp
+    src/ModelViewCamera.cpp
+    src/ScreenSpaceCamera.cpp
+    interface/ModelViewCamera.hpp
+    interface/ScreenSpaceCamera.hpp
 )
 
 target_include_directories(Camera
-        PRIVATE include interface
-        INTERFACE interface
+    PRIVATE include interface
+    INTERFACE interface
 )
 
 set_target_properties(Camera PROPERTIES
-        CXX_STANDARD
-        14
+    CXX_STANDARD
+    14
 )
 
-target_link_libraries(Camera PRIVATE glad GraphicsUtils Logger Video)
+target_link_libraries(Camera
+    PUBLIC
+        Viewport
+    PRIVATE
+        glad
+        GraphicsUtils
+        Logger
+    )

--- a/src/camera/interface/ModelViewCamera.hpp
+++ b/src/camera/interface/ModelViewCamera.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 // Note: For both cameras coordinate system goes as following:
 //
 //   ------ +x
@@ -8,11 +9,13 @@
 //   +y
 //
 
+class Viewport;
+
 class ModelViewCamera
 {
 public:
 
-    ModelViewCamera();
+    ModelViewCamera(std::shared_ptr<Viewport>);
 
     void update_gl_modelview_matrix() const;
     void update_gl_projection_matrix() const;
@@ -35,6 +38,8 @@ private:
 
     void round_position_x();
     void round_position_y();
+    
+    std::shared_ptr<Viewport> _viewport;
 
     float _x = 0;
     float _y = 0;

--- a/src/camera/interface/ScreenSpaceCamera.hpp
+++ b/src/camera/interface/ScreenSpaceCamera.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 // Note: For both cameras coordinate system goes as following:
 //
 //   ------ +x
@@ -8,9 +9,13 @@
 //   +y
 //
 
+class Viewport;
+
 class ScreenSpaceCamera
 {
 public:
+    
+    ScreenSpaceCamera(std::shared_ptr<Viewport>);
 
     void update_gl_modelview_matrix() const;
     void update_gl_projection_matrix() const;
@@ -18,6 +23,8 @@ public:
     void calculate_coefficients();
 
 private:
-
+    
+    std::shared_ptr<Viewport> _viewport;
+    
     float _projection_coefficient;
 };

--- a/src/camera/src/ModelViewCamera.cpp
+++ b/src/camera/src/ModelViewCamera.cpp
@@ -32,7 +32,7 @@ void ModelViewCamera::update_gl_modelview_matrix() const
 
 void ModelViewCamera::update_gl_projection_matrix() const
 {
-    DebugGlCall(glViewport(0, 0, (GLsizei) (_viewport->get_window_width()), (GLsizei) (_viewport->get_window_height())));
+    DebugGlCall(glViewport(0, 0, (GLsizei) (_viewport->get_width()), (GLsizei) (_viewport->get_height())));
     DebugGlCall(glMatrixMode(GL_PROJECTION));
     DebugGlCall(glLoadIdentity());
 

--- a/src/camera/src/ScreenSpaceCamera.cpp
+++ b/src/camera/src/ScreenSpaceCamera.cpp
@@ -1,18 +1,21 @@
 #include <glad/glad.h>
 
 #include "ScreenSpaceCamera.hpp"
-#include "video/Context.hpp"
+#include "viewport/Viewport.hpp"
 #include "graphics_utils/DebugGlCall.hpp"
 #include "graphics_utils/LookAt.hpp"
 
+
+ScreenSpaceCamera::ScreenSpaceCamera(std::shared_ptr<Viewport> viewport)
+    : _viewport(std::move(viewport))
+{}
+
 void ScreenSpaceCamera::update_gl_modelview_matrix() const
 {
-    const auto& video = Video::instance();
-
     // Moving camera, so the [0,0] position would be on the left-lower corner of the screen:
 
-    const float screen_center_x = video.get_window_width() / 2.0f;
-    const float screen_center_y = video.get_window_height() / 2.0f;
+    const float screen_center_x = _viewport->get_window_width() / 2.0f;
+    const float screen_center_y = _viewport->get_window_height() / 2.0f;
 
     const float screen_center_camera_space_x = screen_center_x / 2.0f;
     const float screen_center_camera_space_y = screen_center_y / 2.0f;
@@ -22,16 +25,15 @@ void ScreenSpaceCamera::update_gl_modelview_matrix() const
 
 void ScreenSpaceCamera::update_gl_projection_matrix() const
 {
-    const auto& video = Video::instance();
-    DebugGlCall(glViewport(0, 0, (GLsizei) (video.get_window_width()), (GLsizei) (video.get_window_height())));
+    DebugGlCall(glViewport(0, 0, (GLsizei) (_viewport->get_window_width()), (GLsizei) (_viewport->get_window_height())));
     DebugGlCall(glMatrixMode(GL_PROJECTION));
     DebugGlCall(glLoadIdentity());
 
     static const GLdouble near = -100;
     static const GLdouble far = 100;
 
-    DebugGlCall(glOrtho(-1 * _projection_coefficient * video.get_aspect(), // How much pixels will fit on half of the screen width.
-                        1 * _projection_coefficient * video.get_aspect(),
+    DebugGlCall(glOrtho(-1 * _projection_coefficient * _viewport->get_aspect(), // How much pixels will fit on half of the screen width.
+                        1 * _projection_coefficient * _viewport->get_aspect(),
                         1 * _projection_coefficient, // How much pixels will fit on half of the screen height.
                         -1 * _projection_coefficient,
                         near,
@@ -40,8 +42,5 @@ void ScreenSpaceCamera::update_gl_projection_matrix() const
 
 void ScreenSpaceCamera::calculate_coefficients()
 {
-    const auto& video = Video::instance();
-    _projection_coefficient = (Video::instance().get_window_width() / video.get_aspect()) / 2.0f;
+    _projection_coefficient = (_viewport->get_window_width() / _viewport->get_aspect()) / 2.0f;
 }
-
-

--- a/src/camera/src/ScreenSpaceCamera.cpp
+++ b/src/camera/src/ScreenSpaceCamera.cpp
@@ -14,8 +14,8 @@ void ScreenSpaceCamera::update_gl_modelview_matrix() const
 {
     // Moving camera, so the [0,0] position would be on the left-lower corner of the screen:
 
-    const float screen_center_x = _viewport->get_window_width() / 2.0f;
-    const float screen_center_y = _viewport->get_window_height() / 2.0f;
+    const float screen_center_x = _viewport->get_width() / 2.0f;
+    const float screen_center_y = _viewport->get_height() / 2.0f;
 
     const float screen_center_camera_space_x = screen_center_x / 2.0f;
     const float screen_center_camera_space_y = screen_center_y / 2.0f;
@@ -25,7 +25,7 @@ void ScreenSpaceCamera::update_gl_modelview_matrix() const
 
 void ScreenSpaceCamera::update_gl_projection_matrix() const
 {
-    DebugGlCall(glViewport(0, 0, (GLsizei) (_viewport->get_window_width()), (GLsizei) (_viewport->get_window_height())));
+    DebugGlCall(glViewport(0, 0, (GLsizei) (_viewport->get_width()), (GLsizei) (_viewport->get_height())));
     DebugGlCall(glMatrixMode(GL_PROJECTION));
     DebugGlCall(glLoadIdentity());
 
@@ -42,5 +42,5 @@ void ScreenSpaceCamera::update_gl_projection_matrix() const
 
 void ScreenSpaceCamera::calculate_coefficients()
 {
-    _projection_coefficient = (_viewport->get_window_width() / _viewport->get_aspect()) / 2.0f;
+    _projection_coefficient = (_viewport->get_width() / _viewport->get_aspect()) / 2.0f;
 }

--- a/src/game-loop/CMakeLists.txt
+++ b/src/game-loop/CMakeLists.txt
@@ -71,6 +71,7 @@ set_target_properties(GameLoop PROPERTIES
 target_link_libraries(GameLoop
     PUBLIC
         Camera
+        Viewport
     PRIVATE
         glad
         Logger
@@ -78,6 +79,5 @@ target_link_libraries(GameLoop
         GraphicsUtils
         Renderer
         Collisions
-        Video
         LevelGenerator
 )

--- a/src/game-loop/include/game-objects/HUD.hpp
+++ b/src/game-loop/include/game-objects/HUD.hpp
@@ -6,12 +6,13 @@
 #include "components/QuadComponent.hpp"
 #include "Point2D.hpp"
 #include "TextBuffer.hpp"
+#include "viewport/Viewport.hpp"
 
 class HUD : public GameObject
 {
 public:
 
-    HUD(float pos_x, float pos_y);
+    HUD(std::shared_ptr<Viewport>);
     ~HUD() override;
 
     void update(uint32_t delta_time_ms) override;
@@ -41,6 +42,7 @@ private:
     QuadComponent _hold_item_quad;
 
     std::shared_ptr<TextBuffer> _text_buffer;
+    std::shared_ptr<Viewport> _viewport;
     struct
     {
         TextEntityID hearts = TextBuffer::INVALID_ENTITY;

--- a/src/game-loop/interface/GameLoop.hpp
+++ b/src/game-loop/interface/GameLoop.hpp
@@ -4,6 +4,8 @@
 #include <memory>
 #include <vector>
 
+#include "viewport/Viewport.hpp"
+
 #include "ModelViewCamera.hpp"
 #include "ScreenSpaceCamera.hpp"
 
@@ -16,11 +18,12 @@
 class GameObject;
 class MainDude;
 class TextBuffer;
+class Viewport;
 
 class GameLoop
 {
 public:
-    GameLoop();
+    GameLoop(std::shared_ptr<Viewport>);
     std::function<void(uint32_t delta_time_ms)>& get();
 private:
 
@@ -38,13 +41,14 @@ private:
         GameLoopLevelSummaryState level_summary;
         GameLoopBaseState* current;
     } _states;
-
+    
     struct
     {
         ModelViewCamera model_view;
         ScreenSpaceCamera screen_space;
     } _cameras;
 
+    std::shared_ptr<Viewport> _viewport;
     std::shared_ptr<TextBuffer> _text_buffer;
     std::shared_ptr<MainDude> _main_dude;
     std::vector<std::shared_ptr<GameObject>> _game_objects;

--- a/src/game-loop/src/game-loop/GameLoop.cpp
+++ b/src/game-loop/src/game-loop/GameLoop.cpp
@@ -8,6 +8,7 @@
 #include "Renderer.hpp"
 #include "game-objects/GameObject.hpp"
 #include "main-dude/MainDude.hpp"
+#include "viewport/Viewport.hpp"
 
 #include <algorithm>
 
@@ -16,7 +17,9 @@ std::function<void(uint32_t delta_time_ms)>& GameLoop::get()
     return _loop;
 }
 
-GameLoop::GameLoop()
+GameLoop::GameLoop(std::shared_ptr<Viewport> viewport)
+    : _viewport(std::move(viewport))
+    , _cameras{{_viewport}, {_viewport}}
 {
     _states.current = &_states.started;
     _states.current->enter(*this);

--- a/src/game-loop/src/game-loop/GameLoopPlayingState.cpp
+++ b/src/game-loop/src/game-loop/GameLoopPlayingState.cpp
@@ -1,4 +1,3 @@
-#include "video/Context.hpp"
 #include "LevelGenerator.hpp"
 #include "Level.hpp"
 #include "logger/log.h"
@@ -12,6 +11,8 @@
 #include "game-objects/HUD.hpp"
 #include "main-dude/MainDude.hpp"
 #include "game-objects/TextBuffer.hpp"
+
+#include <ctime>
 
 GameLoopBaseState *GameLoopPlayingState::update(GameLoop& game_loop, uint32_t delta_time_ms)
 {
@@ -76,7 +77,7 @@ void GameLoopPlayingState::enter(GameLoop& game_loop)
 {
     log_info("Entered GameLoopPlayingState");
 
-    std::srand(std::rand() + Video::instance().get_delta_time());
+    std::srand(std::time(0));
 
     LevelGenerator::instance().getLevel().clean_map_layout();
     LevelGenerator::instance().getLevel().generate_new_level_layout();
@@ -97,10 +98,7 @@ void GameLoopPlayingState::enter(GameLoop& game_loop)
 
     // Create hud:
 
-    const auto hud_pos_x = static_cast<float>(Video::instance().get_window_width() * 0.05f);
-    const auto hud_pos_y = static_cast<float>(Video::instance().get_window_height() * 0.05f);
-
-    auto hud = std::make_shared<HUD>(hud_pos_x, hud_pos_y);
+    auto hud = std::make_shared<HUD>(game_loop._viewport);
     game_loop._game_objects.push_back(hud);
 
     // Create text renderer:

--- a/src/game-loop/src/game-objects/HUD.cpp
+++ b/src/game-loop/src/game-objects/HUD.cpp
@@ -1,7 +1,6 @@
 #include <sstream>
 #include <string>
 
-#include "video/Context.hpp"
 #include "game-objects/HUD.hpp"
 #include "spritesheet-frames/HUDSpritesheetFrames.hpp"
 
@@ -63,13 +62,14 @@ void HUD::set_dollars_count(uint32_t dollars)
                               dollars_s.c_str(), dollars_s.size());
 }
 
-HUD::HUD(float pos_x, float pos_y)
-        : _heart_quad(TextureType::HUD, Renderer::EntityType::SCREEN_SPACE, ICON_WIDTH_PIXELS, ICON_HEIGHT_PIXELS)
-        , _dollar_quad(TextureType::HUD, Renderer::EntityType::SCREEN_SPACE, ICON_WIDTH_PIXELS, ICON_HEIGHT_PIXELS)
-        , _ropes_quad(TextureType::HUD, Renderer::EntityType::SCREEN_SPACE, ICON_WIDTH_PIXELS, ICON_HEIGHT_PIXELS)
-        , _bombs_quad(TextureType::HUD, Renderer::EntityType::SCREEN_SPACE, ICON_WIDTH_PIXELS, ICON_HEIGHT_PIXELS)
-        , _hold_item_quad(TextureType::HUD, Renderer::EntityType::SCREEN_SPACE, ICON_WIDTH_PIXELS, ICON_HEIGHT_PIXELS)
-        , _text_buffer(nullptr)
+HUD::HUD(std::shared_ptr<Viewport> viewport)
+    : _heart_quad(TextureType::HUD, Renderer::EntityType::SCREEN_SPACE, ICON_WIDTH_PIXELS, ICON_HEIGHT_PIXELS)
+    , _dollar_quad(TextureType::HUD, Renderer::EntityType::SCREEN_SPACE, ICON_WIDTH_PIXELS, ICON_HEIGHT_PIXELS)
+    , _ropes_quad(TextureType::HUD, Renderer::EntityType::SCREEN_SPACE, ICON_WIDTH_PIXELS, ICON_HEIGHT_PIXELS)
+    , _bombs_quad(TextureType::HUD, Renderer::EntityType::SCREEN_SPACE, ICON_WIDTH_PIXELS, ICON_HEIGHT_PIXELS)
+    , _hold_item_quad(TextureType::HUD, Renderer::EntityType::SCREEN_SPACE, ICON_WIDTH_PIXELS, ICON_HEIGHT_PIXELS)
+    , _text_buffer(nullptr)
+    , _viewport(std::move(viewport))
 {
     _heart_quad.frame_changed<HUDSpritesheetFrames>(HUDSpritesheetFrames::HEART);
     _dollar_quad.frame_changed<HUDSpritesheetFrames>(HUDSpritesheetFrames::DOLLAR_SIGN);
@@ -77,8 +77,11 @@ HUD::HUD(float pos_x, float pos_y)
     _bombs_quad.frame_changed<HUDSpritesheetFrames>(HUDSpritesheetFrames::BOMB_ICON);
     _hold_item_quad.frame_changed<HUDSpritesheetFrames>(HUDSpritesheetFrames::HOLD_ITEM_ICON);
 
-    icons_offset_pixels = Video::instance().get_window_width() * 0.1f;
-
+    icons_offset_pixels = _viewport->get_window_width() * 0.1f;
+    
+    const auto pos_x = static_cast<float>(_viewport->get_window_width() * 0.05f);
+    const auto pos_y = static_cast<float>(_viewport->get_window_height() * 0.05f);
+    
     _heart_center.x = pos_x + (icons_offset_pixels * 0);
     _bombs_center.x = pos_x + (icons_offset_pixels * 1);
     _ropes_center.x = pos_x + (icons_offset_pixels * 2);

--- a/src/game-loop/src/game-objects/HUD.cpp
+++ b/src/game-loop/src/game-objects/HUD.cpp
@@ -77,10 +77,10 @@ HUD::HUD(std::shared_ptr<Viewport> viewport)
     _bombs_quad.frame_changed<HUDSpritesheetFrames>(HUDSpritesheetFrames::BOMB_ICON);
     _hold_item_quad.frame_changed<HUDSpritesheetFrames>(HUDSpritesheetFrames::HOLD_ITEM_ICON);
 
-    icons_offset_pixels = _viewport->get_window_width() * 0.1f;
+    icons_offset_pixels = _viewport->get_width() * 0.1f;
     
-    const auto pos_x = static_cast<float>(_viewport->get_window_width() * 0.05f);
-    const auto pos_y = static_cast<float>(_viewport->get_window_height() * 0.05f);
+    const auto pos_x = static_cast<float>(_viewport->get_width() * 0.05f);
+    const auto pos_y = static_cast<float>(_viewport->get_height() * 0.05f);
     
     _heart_center.x = pos_x + (icons_offset_pixels * 0);
     _bombs_center.x = pos_x + (icons_offset_pixels * 1);

--- a/src/graphics-utils/src/CreateTexture.cpp
+++ b/src/graphics-utils/src/CreateTexture.cpp
@@ -1,7 +1,6 @@
 #include "graphics_utils/DebugGlCall.hpp"
 #include "graphics_utils/CreateTexture.hpp"
 
-#include "glad/glad.h"
 #include "logger/log.h"
 #include "stb/image.h"
 

--- a/src/renderer/CMakeLists.txt
+++ b/src/renderer/CMakeLists.txt
@@ -27,7 +27,6 @@ target_link_libraries(Renderer
         TextureBank
     PRIVATE
         Logger
-        Video
         GraphicsUtils
         cjson
         )

--- a/src/renderer/src/Renderer.cpp
+++ b/src/renderer/src/Renderer.cpp
@@ -1,7 +1,6 @@
 #include "Renderer.hpp"
 #include "TextureBank.hpp"
 #include "TextureType.hpp"
-#include "video/Context.hpp"
 #include "glad/glad.h"
 #include "logger/log.h"
 #include "cJSON.h"

--- a/src/time/interface/time/Timestep.hpp
+++ b/src/time/interface/time/Timestep.hpp
@@ -24,9 +24,7 @@ public:
         _end = SDL_GetTicks();
     }
 
-    void delay() const;
-
-    inline std::uint64_t get_delta_ms() const { return _end - _start;  };
+    Timestamp delay() const;
 
 private:
 

--- a/src/time/src/Timestep.cpp
+++ b/src/time/src/Timestep.cpp
@@ -1,6 +1,6 @@
 #include "time/Timestep.hpp"
 
-void Timestep::delay() const
+Timestamp Timestep::delay() const
 {
     const auto delta_ms = (_end - _start);
 
@@ -13,4 +13,5 @@ void Timestep::delay() const
         auto sleep_time_ms = _frequency - delta_ms;
         SDL_Delay(sleep_time_ms);
     }
+    return delta_ms;
 }

--- a/src/video/CMakeLists.txt
+++ b/src/video/CMakeLists.txt
@@ -20,6 +20,7 @@ set_target_properties(Video PROPERTIES
 target_link_libraries(Video
     PUBLIC
         Time
+        Viewport
     PRIVATE
         Logger
         glad

--- a/src/video/interface/video/Context.hpp
+++ b/src/video/interface/video/Context.hpp
@@ -2,11 +2,14 @@
 // Created by dbeef on 7/7/19.
 //
 
-#ifndef SPELUNKY_PSP_CONTEXT_HPP
-#define SPELUNKY_PSP_CONTEXT_HPP
+#pragma once
 
 #include "time/Timestep.hpp"
+#include "viewport/Viewport.hpp"
+
 #include <functional>
+#include <memory>
+#include <cassert>
 
 class Video {
 
@@ -14,36 +17,19 @@ public:
 
     Video() : _timestep(60) {};
 
-    static void init();
-
-    static void dispose();
-
-    static Video &instance();
-
-    float get_aspect() const;
-
-    uint16_t get_window_width() const;
-
-    uint16_t get_window_height() const;
-
     bool setup_gl();
-
-    inline uint32_t get_delta_time() const { return _timestep.get_delta_ms(); }
 
     void tear_down_gl();
 
     void run_loop(const std::function<void(uint32_t delta_time_ms)> &loop_callback);
 
+    std::shared_ptr<Viewport> get_viewport() const { assert(_viewport); return _viewport; }
+
     inline void swap_buffers() const;
 
 private:
-
-    uint16_t _width = 0;
-    uint16_t _height = 0;
-    float _aspect = 0;
-
     Timestep _timestep;
-    static Video *_instance;
-};
 
-#endif //SPELUNKY_PSP_CONTEXT_HPP
+    std::shared_ptr<Viewport> _viewport;
+
+};

--- a/src/video/src/Context.cpp
+++ b/src/video/src/Context.cpp
@@ -10,42 +10,11 @@
 
 #include <SDL/SDL_video.h>
 #include <SDL/SDL.h>
-#include <cassert>
 
-Video *Video::_instance = nullptr;
-
-void Video::init()
-{
-    assert(!_instance);
-    _instance = new Video();
-}
-
-void Video::dispose()
-{
-    assert(_instance);
-    delete _instance;
-    _instance = nullptr;
-}
-
-Video &Video::instance()
-{
-    assert(_instance);
-    return *_instance;
-}
 
 void Video::tear_down_gl()
 {
     SDL_Quit();
-}
-
-uint16_t Video::get_window_width() const
-{
-    return _width;
-}
-
-uint16_t Video::get_window_height() const
-{
-    return _height;
 }
 
 void Video::swap_buffers() const
@@ -77,12 +46,6 @@ void Video::run_loop(const std::function<void(uint32_t delta_time_ms)> &loop_cal
         swap_buffers();
 
         _timestep.mark_end();
-        _timestep.delay();
-        last_delta_ms = _timestep.get_delta_ms();
+        last_delta_ms = _timestep.delay();
     }
-}
-
-float Video::get_aspect() const
-{
-    return _aspect;
 }

--- a/src/video/src/Context_Desktop.cpp
+++ b/src/video/src/Context_Desktop.cpp
@@ -1,13 +1,13 @@
 //
 // Created by dbeef on 7/7/19.
 //
-
-#include <SDL/SDL.h>
+#include "video/Context.hpp"
 
 #include "graphics_utils/DebugGlCall.hpp"
-#include "video/Context.hpp"
 #include "glad/glad.h"
 #include "logger/log.h"
+
+#include <SDL/SDL.h>
 
 bool Video::setup_gl()
 {
@@ -65,9 +65,7 @@ bool Video::setup_gl()
         return false;
     }
 
-    _width = surface->w;
-    _height = surface->h;
-    _aspect = static_cast<float>(_width) / _height;
+    _viewport = std::make_shared<Viewport>(surface->w, surface->h);
 
     DebugGlCall(glEnable(GL_TEXTURE_2D));
     DebugGlCall(glShadeModel(GL_SMOOTH));

--- a/src/video/src/Context_PSP.cpp
+++ b/src/video/src/Context_PSP.cpp
@@ -39,8 +39,8 @@ bool Video::setup_gl()
     SDL_GL_SetAttribute( SDL_GL_DOUBLEBUFFER, 1 );
 
     //  Create a window
-    auto surface = SDL_SetVideoMode(_viewport->get_window_width(),
-                                    _viewport->get_window_height(),
+    auto surface = SDL_SetVideoMode(_viewport->get_width(),
+                                    _viewport->get_height(),
                                     0, // current display's bpp
                                     SDL_DOUBLEBUF | SDL_OPENGL | SDL_SWSURFACE);
 

--- a/src/video/src/Context_PSP.cpp
+++ b/src/video/src/Context_PSP.cpp
@@ -1,20 +1,17 @@
 //
 // Created by dbeef on 7/7/19.
 //
-
-#include <SDL/SDL.h>
-#include <cassert>
-
 #include "video/Context.hpp"
+
 #include "glad/glad.h"
 #include "graphics_utils/DebugGlCall.hpp"
 #include "logger/log.h"
 
+#include <SDL/SDL.h>
+
 bool Video::setup_gl()
 {
-    _width = 480;
-    _height = 272;
-    _aspect = static_cast<float>(_width) / _height;
+    _viewport = std::make_shared<Viewport>(480, 272);
 
     log_info("Entered Video::setupGL");
 
@@ -42,8 +39,8 @@ bool Video::setup_gl()
     SDL_GL_SetAttribute( SDL_GL_DOUBLEBUFFER, 1 );
 
     //  Create a window
-    auto surface = SDL_SetVideoMode(get_window_width(),
-                                    get_window_height(),
+    auto surface = SDL_SetVideoMode(_viewport->get_window_width(),
+                                    _viewport->get_window_height(),
                                     0, // current display's bpp
                                     SDL_DOUBLEBUF | SDL_OPENGL | SDL_SWSURFACE);
 

--- a/src/viewport/CMakeLists.txt
+++ b/src/viewport/CMakeLists.txt
@@ -1,0 +1,7 @@
+project(Viewport)
+
+add_library(Viewport INTERFACE)
+
+target_include_directories(Viewport
+    INTERFACE interface
+)

--- a/src/viewport/interface/viewport/Viewport.hpp
+++ b/src/viewport/interface/viewport/Viewport.hpp
@@ -12,11 +12,9 @@ public:
         , _aspect(static_cast<float>(_width) / _height)
     { }
 
+    uint16_t get_width() const { return _width; }
+    uint16_t get_height() const { return _height; }
     float get_aspect() const { return _aspect; }
-
-    uint16_t get_window_width() const { return _width; }
-
-    uint16_t get_window_height() const { return _height; }
 
 private:
 

--- a/src/viewport/interface/viewport/Viewport.hpp
+++ b/src/viewport/interface/viewport/Viewport.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cstdint>
+
+class Viewport final
+{
+public:
+
+    Viewport(uint16_t width, uint16_t height)
+        : _width(width)
+        , _height(height)
+        , _aspect(static_cast<float>(_width) / _height)
+    { }
+
+    float get_aspect() const { return _aspect; }
+
+    uint16_t get_window_width() const { return _width; }
+
+    uint16_t get_window_height() const { return _height; }
+
+private:
+
+    const uint16_t _width;
+    const uint16_t _height;
+    const float _aspect;
+};


### PR DESCRIPTION
I'd like to introduce this decoupling in order to remove Video's two-face behaviour - no code other than `Main.cpp` should have access to display functions. Most of what's inside the game actually only needs viewport hints.

Also, I removed another singleton!

Rafal