### PR TITLE
Remove SDL_1_XX from Dependencies target

### DIFF
--- a/cmake/DependenciesLinux.cmake
+++ b/cmake/DependenciesLinux.cmake
@@ -6,7 +6,6 @@ macro(add_linux_dependencies)
 
     add_library(Dependencies INTERFACE)
     target_link_libraries(Dependencies INTERFACE
-            SDL_1_XX
             -lGL
             -lX11
             -ldl

--- a/cmake/DependenciesPSP.cmake
+++ b/cmake/DependenciesPSP.cmake
@@ -9,7 +9,6 @@ macro(add_psp_dependencies)
     add_library(Dependencies INTERFACE)
     target_link_libraries(Dependencies INTERFACE
             -L${PSPDEV}/psp/lib
-            SDL_1_XX
             -lg
             -lstdc++
             -lc

--- a/cmake/DependenciesWindows.cmake
+++ b/cmake/DependenciesWindows.cmake
@@ -8,7 +8,6 @@ macro(add_windows_dependencies)
     target_link_libraries(SDL_1_XX INTERFACE ${SDL_LIBRARY})
 
     add_library(Dependencies INTERFACE)
-    target_link_libraries(Dependencies INTERFACE SDL_1_XX)
 
     target_compile_definitions(Dependencies INTERFACE
             SPELUNKY_PSP_PLATFORM_WINDOWS


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19894088/84709679-e7de9000-af62-11ea-97ad-0850f49f8612.png)

For Windows, the `Dependencies` target is empty, but I've decoupled it from SDL now
