### PR TITLE
Decoupled GameLoop from glad & GraphicsUtils

### DIFF
--- a/src/game-loop/CMakeLists.txt
+++ b/src/game-loop/CMakeLists.txt
@@ -73,10 +73,8 @@ target_link_libraries(GameLoop
         Camera
         Viewport
     PRIVATE
-        glad
         Logger
         Input
-        GraphicsUtils
         Renderer
         Collisions
         LevelGenerator

--- a/src/game-loop/src/game-loop/GameLoop.cpp
+++ b/src/game-loop/src/game-loop/GameLoop.cpp
@@ -1,16 +1,7 @@
-#include "LevelGenerator.hpp"
-#include "SplashScreenType.hpp"
-#include "ModelViewCamera.hpp"
-#include "Input.hpp"
 #include "GameLoop.hpp"
-#include "glad/glad.h"
-#include "graphics_utils/DebugGlCall.hpp"
-#include "Renderer.hpp"
-#include "game-objects/GameObject.hpp"
-#include "main-dude/MainDude.hpp"
-#include "viewport/Viewport.hpp"
 
 #include <algorithm>
+#include <cassert>
 
 std::function<void(uint32_t delta_time_ms)>& GameLoop::get()
 {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19894088/84711460-b5cf2d00-af66-11ea-8207-d5f1a42f4506.png)
(this is after rebasing on previous PRs)

One thing that made me worried is graphviz not visualising the fact that `Input` depends on `SDL`. This could be a limitation of the tool.