### PR TITLE
Proposal for simple glad removal in CMake dependencies tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,6 @@ target_link_libraries(Spelunky_PSP PRIVATE
         LevelGenerator
         Renderer
         Input
-        GraphicsUtils
         GameLoop
         TextureBank
         Dependencies

--- a/src/camera/CMakeLists.txt
+++ b/src/camera/CMakeLists.txt
@@ -21,7 +21,6 @@ target_link_libraries(Camera
     PUBLIC
         Viewport
     PRIVATE
-        glad
         GraphicsUtils
         Logger
     )

--- a/src/texture-bank/CMakeLists.txt
+++ b/src/texture-bank/CMakeLists.txt
@@ -33,7 +33,6 @@ endif()
 
 target_link_libraries(TextureBank
     PUBLIC
-        glad
         Renderer
     PRIVATE
         Logger

--- a/src/texture-bank/interface/TextureBank.hpp
+++ b/src/texture-bank/interface/TextureBank.hpp
@@ -3,13 +3,12 @@
 #include "TextureType.hpp"
 #include "TextureRegion.hpp"
 
-#include <glad/glad.h>
 #include <unordered_map>
 #include <vector>
 #include <cassert>
 #include <cstdint>
 
-using TextureID = GLuint;
+using TextureID = unsigned int;
 const TextureID INVALID_TEXTURE = 0;
 const TextureRegion INVALID_REGION = {};
 

--- a/src/texture-bank/interface/TextureRegion.hpp
+++ b/src/texture-bank/interface/TextureRegion.hpp
@@ -5,7 +5,6 @@
 #ifndef RESOURCE_COMPILER_TEXTUREREGION_HPP
 #define RESOURCE_COMPILER_TEXTUREREGION_HPP
 
-#include "glad/glad.h"
 #include "Mesh.hpp"
 #include "Quad.hpp"
 


### PR DESCRIPTION
Removes glad where it's obsolete or easy to hide from the interface