### PR TITLE
Proposal for Windows timing fix

### DIFF
--- a/src/time/interface/time/Timestep.hpp
+++ b/src/time/interface/time/Timestep.hpp
@@ -4,15 +4,16 @@
 #include <thread>
 
 using Timestamp = Uint32;
-using Frequency = Uint32;
+using Timediff = Uint32;
 
 class Timestep {
 
 public:
 
-    explicit Timestep(float fps = 60) : _fps(fps), _frequency(1000.0f * (1.0f / fps))
-    {
-    }
+    explicit Timestep(float fps = 60.f)
+        : _fps(fps)
+        , _min_delay_ms(1000.0f * (1.0f / fps))
+    { }
 
     inline void mark_start()
     {
@@ -30,6 +31,6 @@ private:
 
     Timestamp _start;
     Timestamp _end;
-    const Frequency _frequency;
     const float _fps;
+    const Timediff _min_delay_ms;
 };

--- a/src/time/interface/time/Timestep.hpp
+++ b/src/time/interface/time/Timestep.hpp
@@ -24,7 +24,6 @@ public:
         _end = SDL_GetTicks();
     }
 
-    // Returns time spent on delay in milliseconds.
     Timestamp delay() const;
 
 private:

--- a/src/time/interface/time/Timestep.hpp
+++ b/src/time/interface/time/Timestep.hpp
@@ -12,7 +12,7 @@ public:
 
     explicit Timestep(float fps = 60.f)
         : _fps(fps)
-        , _min_delay_ms(1000.0f * (1.0f / fps))
+        , _min_delay_ms(static_cast<Timediff>(1000.0f / fps))
     { }
 
     inline void mark_start()

--- a/src/time/interface/time/Timestep.hpp
+++ b/src/time/interface/time/Timestep.hpp
@@ -24,6 +24,7 @@ public:
         _end = SDL_GetTicks();
     }
 
+    // Returns time spent on delay in milliseconds.
     Timestamp delay() const;
 
 private:

--- a/src/time/src/Timestep.cpp
+++ b/src/time/src/Timestep.cpp
@@ -7,11 +7,13 @@ Timestamp Timestep::delay() const
     if (delta_ms > _frequency)
     {
         // no delay
+        return delta_ms;
     }
     else
     {
         auto sleep_time_ms = _frequency - delta_ms;
         SDL_Delay(sleep_time_ms);
+        return sleep_time_ms;
     }
     return delta_ms;
 }

--- a/src/time/src/Timestep.cpp
+++ b/src/time/src/Timestep.cpp
@@ -4,11 +4,11 @@ Timestamp Timestep::delay() const
 {
     const auto delta_ms = (_end - _start);
 
-    if (delta_ms <= _frequency)
+    if (delta_ms < _min_delay_ms)
     {
-        const auto sleep_time_ms = _frequency - delta_ms;
+        const auto sleep_time_ms = _min_delay_ms - delta_ms;
         SDL_Delay(sleep_time_ms);
-        return _frequency;
+        return _min_delay_ms;
     }
     return delta_ms;
 }

--- a/src/time/src/Timestep.cpp
+++ b/src/time/src/Timestep.cpp
@@ -4,16 +4,11 @@ Timestamp Timestep::delay() const
 {
     const auto delta_ms = (_end - _start);
 
-    if (delta_ms > _frequency)
+    if (delta_ms <= _frequency)
     {
-        // no delay
-        return delta_ms;
-    }
-    else
-    {
-        auto sleep_time_ms = _frequency - delta_ms;
+        const auto sleep_time_ms = _frequency - delta_ms;
         SDL_Delay(sleep_time_ms);
-        return sleep_time_ms;
+        return _frequency;
     }
     return delta_ms;
 }

--- a/src/video/interface/video/Context.hpp
+++ b/src/video/interface/video/Context.hpp
@@ -19,6 +19,7 @@ public:
 
     bool setup_gl();
 
+    inline uint32_t get_delta_time() const { return _last_delta_time; }
     void tear_down_gl();
 
     void run_loop(const std::function<void(uint32_t delta_time_ms)> &loop_callback);
@@ -31,5 +32,6 @@ private:
     Timestep _timestep;
 
     std::shared_ptr<Viewport> _viewport;
+    uint32_t _last_delta_time = 0;
 
 };

--- a/src/video/src/Context.cpp
+++ b/src/video/src/Context.cpp
@@ -27,8 +27,6 @@ void Video::run_loop(const std::function<void(uint32_t delta_time_ms)> &loop_cal
 
     auto& input = Input::instance();
 
-    static uint32_t last_delta_ms = 0;
-
     while (!input.isExit()) {
 
         _timestep.mark_start();
@@ -36,7 +34,7 @@ void Video::run_loop(const std::function<void(uint32_t delta_time_ms)> &loop_cal
 #ifndef NDEBUG
         DebugGlCall(glClear(GL_COLOR_BUFFER_BIT));
 #endif
-        loop_callback(last_delta_ms);
+        loop_callback(_last_delta_time);
         // Force GPU to render commands queued in the callback:
         DebugGlCall(glFlush());
         // Now CPU-consuming calls for the rest of the frame:
@@ -46,6 +44,6 @@ void Video::run_loop(const std::function<void(uint32_t delta_time_ms)> &loop_cal
         swap_buffers();
 
         _timestep.mark_end();
-        last_delta_ms = _timestep.delay();
+        _last_delta_time = _timestep.delay();
     }
 }


### PR DESCRIPTION
`Timestep::delay()` wasn't doing what it was supposed to. 

I would suggest a different approach whatsoever, for the physics engine to work better: either cumulating time differences to apply when they pass minimum timing thresholds, or uncapping the framerate and using non-floating point variables to track time, velocity and position changes

I would appreciate testing on Linux.

Waiting for #33 to be merged first