### PR TITLE
Input interface refactor - mapping keys to specific actions

### DIFF
--- a/src/game-loop/src/main-dude/states/MainDudeCliffHangingState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeCliffHangingState.cpp
@@ -21,7 +21,7 @@ MainDudeBaseState* MainDudeCliffHangingState::update(MainDude& main_dude, uint32
 
 MainDudeBaseState *MainDudeCliffHangingState::handle_input(MainDude& main_dude, const Input &input)
 {
-    if (input.circle())
+    if (input.jumping())
     {
         main_dude._physics.add_velocity(0.0f, -MainDude::JUMP_SPEED);
         main_dude._physics.enable_gravity();

--- a/src/game-loop/src/main-dude/states/MainDudeClimbingLadderState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeClimbingLadderState.cpp
@@ -45,7 +45,7 @@ MainDudeBaseState* MainDudeClimbingLadderState::update(MainDude& main_dude, uint
 
 MainDudeBaseState *MainDudeClimbingLadderState::handle_input(MainDude& main_dude, const Input &input)
 {
-    if (input.circle())
+    if (input.jumping())
     {
         main_dude._physics.add_velocity(0.0f, -MainDude::JUMP_SPEED);
         main_dude._physics.enable_gravity();

--- a/src/game-loop/src/main-dude/states/MainDudeCrawlingState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeCrawlingState.cpp
@@ -47,17 +47,17 @@ MainDudeBaseState *MainDudeCrawlingState::handle_input(MainDude& main_dude, cons
     {
         main_dude._physics.add_velocity(MainDude::CRAWLING_DELTA_X, 0.0f);
     }
-    if (input.circle())
+    if (input.jumping())
     {
         main_dude._physics.add_velocity(0.0f, -MainDude::JUMP_SPEED);
         return &main_dude._states.jumping;
     }
-    if (!input.cross())
+    if (!input.ducking())
     {
         return &main_dude._states.running;
     }
 
-    if (input.bumper_r())
+    if (input.throwing())
     {
         return &main_dude._states.throwing;
     }

--- a/src/game-loop/src/main-dude/states/MainDudeDuckingState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeDuckingState.cpp
@@ -46,17 +46,17 @@ MainDudeBaseState *MainDudeDuckingState::handle_input(MainDude& main_dude, const
         main_dude._physics.add_velocity(MainDude::DEFAULT_DELTA_X, 0.0f);
         return &main_dude._states.crawling;
     }
-    if (input.circle())
+    if (input.jumping())
     {
         main_dude._physics.add_velocity(0.0f, -MainDude::JUMP_SPEED);
         return &main_dude._states.jumping;
     }
-    if (!input.cross())
+    if (!input.ducking())
     {
         return &main_dude._states.standing;
     }
 
-    if (input.bumper_r())
+    if (input.throwing())
     {
         return &main_dude._states.throwing;
     }

--- a/src/game-loop/src/main-dude/states/MainDudeFallingState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeFallingState.cpp
@@ -98,7 +98,7 @@ MainDudeBaseState *MainDudeFallingState::handle_input(MainDude& main_dude, const
         }
     }
 
-    if (input.bumper_l())
+    if (input.running_fast())
     {
         main_dude._physics.set_max_x_velocity(MainDude::MAX_RUNNING_VELOCITY_X);
         main_dude._animation.set_time_per_frame_ms(50);
@@ -109,7 +109,7 @@ MainDudeBaseState *MainDudeFallingState::handle_input(MainDude& main_dude, const
         main_dude._animation.set_time_per_frame_ms(75);
     }
 
-    if (input.bumper_r())
+    if (input.throwing())
     {
         return &main_dude._states.throwing;
     }

--- a/src/game-loop/src/main-dude/states/MainDudeJumpingState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeJumpingState.cpp
@@ -99,7 +99,7 @@ MainDudeBaseState *MainDudeJumpingState::handle_input(MainDude& main_dude, const
         }
     }
 
-    if (input.bumper_l())
+    if (input.running_fast())
     {
         main_dude._physics.set_max_x_velocity(MainDude::MAX_RUNNING_VELOCITY_X);
         main_dude._animation.set_time_per_frame_ms(50);
@@ -110,7 +110,7 @@ MainDudeBaseState *MainDudeJumpingState::handle_input(MainDude& main_dude, const
         main_dude._animation.set_time_per_frame_ms(75);
     }
 
-    if (input.bumper_r())
+    if (input.throwing())
     {
         return &main_dude._states.throwing;
     }

--- a/src/game-loop/src/main-dude/states/MainDudeLookingUpState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeLookingUpState.cpp
@@ -45,12 +45,12 @@ MainDudeBaseState *MainDudeLookingUpState::handle_input(MainDude& main_dude, con
     {
         main_dude._physics.add_velocity(MainDude::DEFAULT_DELTA_X, 0.0f);
     }
-    if (input.circle())
+    if (input.jumping())
     {
         main_dude._physics.add_velocity(0.0f, -MainDude::JUMP_SPEED);
         return &main_dude._states.jumping;
     }
-    if (input.bumper_r())
+    if (input.throwing())
     {
         return &main_dude._states.throwing;
     }

--- a/src/game-loop/src/main-dude/states/MainDudePushingState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudePushingState.cpp
@@ -54,17 +54,17 @@ MainDudeBaseState *MainDudePushingState::handle_input(MainDude& main_dude, const
         return &main_dude._states.running;
     }
 
-    if (input.circle())
+    if (input.jumping())
     {
         main_dude._physics.add_velocity(0.0f, -MainDude::JUMP_SPEED);
         return &main_dude._states.jumping;
     }
-    if (input.cross())
+    if (input.ducking())
     {
         return &main_dude._states.ducking;
     }
 
-    if (input.bumper_r())
+    if (input.throwing())
     {
         return &main_dude._states.throwing;
     }

--- a/src/game-loop/src/main-dude/states/MainDudeRunningLookingUpState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeRunningLookingUpState.cpp
@@ -56,17 +56,17 @@ MainDudeBaseState *MainDudeRunningLookingUpState::handle_input(MainDude& main_du
     {
         main_dude._physics.add_velocity(MainDude::DEFAULT_DELTA_X, 0.0f);
     }
-    if (input.circle())
+    if (input.jumping())
     {
         main_dude._physics.add_velocity(0.0f, -MainDude::JUMP_SPEED);
         return &main_dude._states.jumping;
     }
-    if (input.cross())
+    if (input.ducking())
     {
         return &main_dude._states.crawling;
     }
 
-    if (input.bumper_l())
+    if (input.running_fast())
     {
         main_dude._physics.set_max_x_velocity(MainDude::MAX_RUNNING_VELOCITY_X);
         main_dude._animation.set_time_per_frame_ms(50);
@@ -77,7 +77,7 @@ MainDudeBaseState *MainDudeRunningLookingUpState::handle_input(MainDude& main_du
         main_dude._animation.set_time_per_frame_ms(75);
     }
 
-    if (input.bumper_r())
+    if (input.throwing())
     {
         return &main_dude._states.throwing;
     }

--- a/src/game-loop/src/main-dude/states/MainDudeRunningState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeRunningState.cpp
@@ -55,17 +55,17 @@ MainDudeBaseState *MainDudeRunningState::handle_input(MainDude& main_dude, const
     {
         main_dude._physics.add_velocity(MainDude::DEFAULT_DELTA_X, 0.0f);
     }
-    if (input.circle())
+    if (input.jumping())
     {
         main_dude._physics.add_velocity(0.0f, -MainDude::JUMP_SPEED);
         return &main_dude._states.jumping;
     }
-    if (input.cross())
+    if (input.ducking())
     {
         return &main_dude._states.crawling;
     }
 
-    if (input.bumper_l())
+    if (input.running_fast())
     {
         main_dude._physics.set_max_x_velocity(MainDude::MAX_RUNNING_VELOCITY_X);
         main_dude._animation.set_time_per_frame_ms(50);
@@ -76,7 +76,7 @@ MainDudeBaseState *MainDudeRunningState::handle_input(MainDude& main_dude, const
         main_dude._animation.set_time_per_frame_ms(75);
     }
 
-    if (input.bumper_r())
+    if (input.throwing())
     {
         return &main_dude._states.throwing;
     }

--- a/src/game-loop/src/main-dude/states/MainDudeStandingState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeStandingState.cpp
@@ -61,16 +61,16 @@ MainDudeBaseState *MainDudeStandingState::handle_input(MainDude& main_dude, cons
     {
         main_dude._physics.add_velocity(MainDude::DEFAULT_DELTA_X, 0.0f);
     }
-    if (input.circle())
+    if (input.jumping())
     {
         main_dude._physics.add_velocity(0.0f, -MainDude::JUMP_SPEED);
         return &main_dude._states.jumping;
     }
-    if (input.cross())
+    if (input.ducking())
     {
         return &main_dude._states.ducking;
     }
-    if (input.bumper_r())
+    if (input.throwing())
     {
         return &main_dude._states.throwing;
     }

--- a/src/game-loop/src/main-dude/states/MainDudeThrowingState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeThrowingState.cpp
@@ -58,12 +58,12 @@ MainDudeBaseState *MainDudeThrowingState::handle_input(MainDude& main_dude, cons
     {
         main_dude._physics.add_velocity(MainDude::DEFAULT_DELTA_X, 0.0f);
     }
-    if (input.triangle() && main_dude._physics.is_bottom_collision())
+    if (input.jumping() && main_dude._physics.is_bottom_collision())
     {
         main_dude._physics.add_velocity(0.0f, -MainDude::JUMP_SPEED);
     }
 
-    if (input.bumper_l())
+    if (input.running_fast())
     {
         main_dude._physics.set_max_x_velocity(MainDude::MAX_RUNNING_VELOCITY_X);
     }

--- a/src/input/interface/Input.hpp
+++ b/src/input/interface/Input.hpp
@@ -10,37 +10,33 @@ public:
 
     void poll();
 
-    inline bool isExit() const { return _exit; }
+    inline bool paused() const { return _paused; }
 
     inline bool left() const { return _left; }
     inline bool right() const { return _right; }
     inline bool up() const { return _up; }
     inline bool down() const { return _down; }
 
-    inline bool square() const { return _square; }
-    inline bool circle() const { return _circle; }
-    inline bool triangle() const { return _triangle; }
-    inline bool cross() const { return _cross; }
+    inline bool jumping() const { return _jumping; }
+    inline bool ducking() const { return _ducking; }
 
-    inline bool bumper_l() const { return _bumper_l; }
-    inline bool bumper_r() const { return _bumper_r; }
+    inline bool running_fast() const { return _running_fast; }
+    inline bool throwing() const { return _throwing; }
 
 private:
 
-    bool _exit = false;
+    bool _paused = false;
 
     bool _left = false;
     bool _right = false;
     bool _up = false;
     bool _down = false;
 
-    bool _square = false;
-    bool _circle = false;
-    bool _triangle = false;
-    bool _cross = false;
+    bool _jumping = false;
+    bool _ducking = false;
 
-    bool _bumper_l = false;
-    bool _bumper_r = false;
+    bool _running_fast = false;
+    bool _throwing = false;
 
     static Input* _input;
 };

--- a/src/input/src/Input_Desktop.cpp
+++ b/src/input/src/Input_Desktop.cpp
@@ -9,8 +9,8 @@ void Input::poll()
 
     while (SDL_PollEvent(&event))
     {
-        _exit = event.type == SDL_QUIT || (event.type == SDL_EventType::SDL_KEYDOWN && event.key.keysym.sym == SDLK_ESCAPE);
-        if (_exit)
+        _paused = event.type == SDL_QUIT || (event.type == SDL_EventType::SDL_KEYDOWN && event.key.keysym.sym == SDLK_ESCAPE);
+        if (_paused)
         {
             // FIXME: Better exit handling
             std::exit(0);
@@ -37,29 +37,21 @@ void Input::poll()
             {
                 _down = v;
             }
-            else if (key == SDLK_w)
-            {
-                _triangle = v;
-            }
-            else if (key == SDLK_a)
-            {
-                _square = v;
-            }
             else if (key == SDLK_d)
             {
-                _circle = v;
+                _jumping = v;
             }
             else if (key == SDLK_s)
             {
-                _cross = v;
+                _ducking = v;
             }
             else if (key == SDLK_LSHIFT)
             {
-                _bumper_l = v;
+                _running_fast = v;
             }
             else if (key == SDLK_q)
             {
-                _bumper_r = v;
+                _throwing = v;
             }
         }
     }

--- a/src/input/src/Input_PSP.cpp
+++ b/src/input/src/Input_PSP.cpp
@@ -21,11 +21,9 @@ void Input::poll()
     _left = pad.Buttons & PSP_CTRL_LEFT;
     _right = pad.Buttons & PSP_CTRL_RIGHT;
 
-    _triangle = pad.Buttons & PSP_CTRL_TRIANGLE;
-    _cross = pad.Buttons & PSP_CTRL_CROSS;
-    _square = pad.Buttons & PSP_CTRL_SQUARE;
-    _circle = pad.Buttons & PSP_CTRL_CIRCLE;
+    _jumping = pad.Buttons & PSP_CTRL_CROSS;
+    _ducking = pad.Buttons & PSP_CTRL_CIRCLE;
 
-    _bumper_l = pad.Buttons & PSP_CTRL_LTRIGGER;
-    _bumper_r = pad.Buttons & PSP_CTRL_RTRIGGER;
+    _running_fast = pad.Buttons & PSP_CTRL_LTRIGGER;
+    _throwing = pad.Buttons & PSP_CTRL_RTRIGGER;
 }

--- a/src/video/src/Context.cpp
+++ b/src/video/src/Context.cpp
@@ -26,7 +26,7 @@ void Video::run_loop(const std::function<void(uint32_t delta_time_ms)> &loop_cal
 
     auto& input = Input::instance();
 
-    while (!input.isExit()) {
+    while (!input.paused()) {
 
         _timestep.mark_start();
 


### PR DESCRIPTION
Remembering key-action mapping is troubling, better to place it in the interface directly and resolve mapping in
the platform-specific implementation.