### PR TITLE
Screen-space quads using world-units to adapt to non-fixed resolution

### DIFF
--- a/src/camera/interface/ScreenSpaceCamera.hpp
+++ b/src/camera/interface/ScreenSpaceCamera.hpp
@@ -14,8 +14,14 @@ class Viewport;
 class ScreenSpaceCamera
 {
 public:
-    
-    ScreenSpaceCamera(std::shared_ptr<Viewport>);
+
+    enum class CoordinateType
+    {
+        WORLD_UNITS,
+        PIXELS
+    };
+
+    ScreenSpaceCamera(std::shared_ptr<Viewport>, CoordinateType);
 
     void update_gl_modelview_matrix() const;
     void update_gl_projection_matrix() const;
@@ -25,6 +31,6 @@ public:
 private:
     
     std::shared_ptr<Viewport> _viewport;
-    
+    CoordinateType _coordinate_type;
     float _projection_coefficient;
 };

--- a/src/camera/src/ScreenSpaceCamera.cpp
+++ b/src/camera/src/ScreenSpaceCamera.cpp
@@ -1,3 +1,4 @@
+#include <cassert>
 #include <glad/glad.h>
 
 #include "ScreenSpaceCamera.hpp"
@@ -6,16 +7,37 @@
 #include "graphics_utils/LookAt.hpp"
 
 
-ScreenSpaceCamera::ScreenSpaceCamera(std::shared_ptr<Viewport> viewport)
+ScreenSpaceCamera::ScreenSpaceCamera(std::shared_ptr<Viewport> viewport, CoordinateType coordinate_type)
     : _viewport(std::move(viewport))
+    , _coordinate_type(coordinate_type)
 {}
 
 void ScreenSpaceCamera::update_gl_modelview_matrix() const
 {
     // Moving camera, so the [0,0] position would be on the left-lower corner of the screen:
 
-    const float screen_center_x = _viewport->get_width() / 2.0f;
-    const float screen_center_y = _viewport->get_height() / 2.0f;
+    float screen_center_x;
+    float screen_center_y;
+
+    switch (_coordinate_type)
+    {
+        case CoordinateType::WORLD_UNITS:
+        {
+            screen_center_x = _viewport->get_width_world_units() / 2.0f;
+            screen_center_y = _viewport->get_height_world_units() / 2.0f;
+            break;
+        }
+        case CoordinateType::PIXELS:
+        {
+            screen_center_x = _viewport->get_width_pixels() / 2.0f;
+            screen_center_y = _viewport->get_height_pixels() / 2.0f;
+            break;
+        }
+        default:
+        {
+            assert(false);
+        }
+    }
 
     const float screen_center_camera_space_x = screen_center_x / 2.0f;
     const float screen_center_camera_space_y = screen_center_y / 2.0f;
@@ -25,16 +47,16 @@ void ScreenSpaceCamera::update_gl_modelview_matrix() const
 
 void ScreenSpaceCamera::update_gl_projection_matrix() const
 {
-    DebugGlCall(glViewport(0, 0, (GLsizei) (_viewport->get_width()), (GLsizei) (_viewport->get_height())));
+    DebugGlCall(glViewport(0, 0, (GLsizei) (_viewport->get_width_pixels()), (GLsizei) (_viewport->get_height_pixels())));
     DebugGlCall(glMatrixMode(GL_PROJECTION));
     DebugGlCall(glLoadIdentity());
 
     static const GLdouble near = -100;
     static const GLdouble far = 100;
 
-    DebugGlCall(glOrtho(-1 * _projection_coefficient * _viewport->get_aspect(), // How much pixels will fit on half of the screen width.
+    DebugGlCall(glOrtho(-1 * _projection_coefficient * _viewport->get_aspect(), // How much pixels or world units will fit on half of the screen width.
                         1 * _projection_coefficient * _viewport->get_aspect(),
-                        1 * _projection_coefficient, // How much pixels will fit on half of the screen height.
+                        1 * _projection_coefficient, // How much pixels or world units will fit on half of the screen height.
                         -1 * _projection_coefficient,
                         near,
                         far));
@@ -42,5 +64,21 @@ void ScreenSpaceCamera::update_gl_projection_matrix() const
 
 void ScreenSpaceCamera::calculate_coefficients()
 {
-    _projection_coefficient = (_viewport->get_width() / _viewport->get_aspect()) / 2.0f;
+    switch (_coordinate_type)
+    {
+        case CoordinateType::WORLD_UNITS:
+        {
+            _projection_coefficient = _viewport->calculate_coefficient_world_units();
+            break;
+        }
+        case CoordinateType::PIXELS:
+        {
+            _projection_coefficient = _viewport->calculate_coefficient_pixels();
+            break;
+        }
+        default:
+        {
+            assert(false);
+        }
+    }
 }

--- a/src/game-loop/include/game-objects/HUD.hpp
+++ b/src/game-loop/include/game-objects/HUD.hpp
@@ -24,11 +24,6 @@ public:
 
 private:
 
-    // TODO: Scale depending on screen resolution.
-    const float ICON_WIDTH_PIXELS = 16;
-    const float ICON_HEIGHT_PIXELS = 16;
-    float icons_offset_pixels = 0.0f;
-
     Point2D _heart_center;
     Point2D _dollar_center;
     Point2D _ropes_center;

--- a/src/game-loop/include/game-objects/TextBuffer.hpp
+++ b/src/game-loop/include/game-objects/TextBuffer.hpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <vector>
 
+#include "viewport/Viewport.hpp"
 #include "spritesheet-frames/FontSpritesheetFrames.hpp"
 #include "components/QuadComponent.hpp"
 #include "GameObject.hpp"
@@ -15,6 +16,9 @@ class TextBuffer : public GameObject
 public:
 
     static const TextEntityID INVALID_ENTITY = 0;
+    static WorldUnit_t get_font_width() { return 0.5f; }
+    static WorldUnit_t get_font_height() { return 0.5f; }
+    static WorldUnit_t get_font_offset() { return 0.5f; }
 
     void update(uint32_t delta_time_ms) override;
     TextEntityID create_text();
@@ -31,9 +35,4 @@ private:
 
     std::vector<TextEntityID > _for_removal;
     std::vector<TextEntity> _text_entries;
-
-    // FIXME: Expose in the public interface.
-    const float FONT_WIDTH_PIXELS = 16;
-    const float FONT_HEIGHT_PIXELS = 16;
-    const float OFFSET_PIXELS = 16;
 };

--- a/src/game-loop/src/game-loop/GameLoop.cpp
+++ b/src/game-loop/src/game-loop/GameLoop.cpp
@@ -10,7 +10,7 @@ std::function<bool(uint32_t delta_time_ms)>& GameLoop::get()
 
 GameLoop::GameLoop(const std::shared_ptr<Viewport>& viewport)
     : _viewport(viewport)
-    , _cameras{{viewport}, {viewport}}
+    , _cameras{{viewport}, {viewport, ScreenSpaceCamera::CoordinateType::WORLD_UNITS}}
 {
     _states.current = &_states.started;
     _states.current->enter(*this);

--- a/src/game-loop/src/game-objects/HUD.cpp
+++ b/src/game-loop/src/game-objects/HUD.cpp
@@ -37,37 +37,42 @@ void HUD::set_text_buffer(const std::shared_ptr<TextBuffer> &text_buffer)
 void HUD::set_hearts_count(uint32_t hearts)
 {
     const auto hearts_s = to_string(hearts);
-    _text_buffer->update_text(_text_entity_ids.hearts, {_heart_center.x + (icons_offset_pixels / 2.0f), _heart_center.y},
+    _text_buffer->update_text(_text_entity_ids.hearts, {_heart_center.x + TextBuffer::get_font_offset(), _heart_center.y},
                               hearts_s.c_str(), hearts_s.size());
 }
 
 void HUD::set_ropes_count(uint32_t ropes)
 {
     const auto ropes_s = to_string(ropes);
-    _text_buffer->update_text(_text_entity_ids.ropes, {_ropes_center.x + (icons_offset_pixels / 2.0f), _ropes_center.y},
+    _text_buffer->update_text(_text_entity_ids.ropes, {_ropes_center.x + TextBuffer::get_font_offset(), _ropes_center.y},
                               ropes_s.c_str(), ropes_s.size());
 }
 
 void HUD::set_bombs_count(uint32_t bombs)
 {
     const auto bombs_s = to_string(bombs);
-    _text_buffer->update_text(_text_entity_ids.bombs, {_bombs_center.x + (icons_offset_pixels / 2.0f), _bombs_center.y},
+    _text_buffer->update_text(_text_entity_ids.bombs, {_bombs_center.x + TextBuffer::get_font_offset(), _bombs_center.y},
                               bombs_s.c_str(), bombs_s.size());
 }
 
 void HUD::set_dollars_count(uint32_t dollars)
 {
     const auto dollars_s = to_string(dollars);
-    _text_buffer->update_text(_text_entity_ids.dollars, {_dollar_center.x + (icons_offset_pixels / 2.0f), _dollar_center.y},
+    _text_buffer->update_text(_text_entity_ids.dollars, {_dollar_center.x + TextBuffer::get_font_offset(), _dollar_center.y},
                               dollars_s.c_str(), dollars_s.size());
 }
 
 HUD::HUD(std::shared_ptr<Viewport> viewport)
-    : _heart_quad(TextureType::HUD, Renderer::EntityType::SCREEN_SPACE, ICON_WIDTH_PIXELS, ICON_HEIGHT_PIXELS)
-    , _dollar_quad(TextureType::HUD, Renderer::EntityType::SCREEN_SPACE, ICON_WIDTH_PIXELS, ICON_HEIGHT_PIXELS)
-    , _ropes_quad(TextureType::HUD, Renderer::EntityType::SCREEN_SPACE, ICON_WIDTH_PIXELS, ICON_HEIGHT_PIXELS)
-    , _bombs_quad(TextureType::HUD, Renderer::EntityType::SCREEN_SPACE, ICON_WIDTH_PIXELS, ICON_HEIGHT_PIXELS)
-    , _hold_item_quad(TextureType::HUD, Renderer::EntityType::SCREEN_SPACE, ICON_WIDTH_PIXELS, ICON_HEIGHT_PIXELS)
+    : _heart_quad(TextureType::HUD, Renderer::EntityType::SCREEN_SPACE, TextBuffer::get_font_width(),
+                  TextBuffer::get_font_height())
+    , _dollar_quad(TextureType::HUD, Renderer::EntityType::SCREEN_SPACE, TextBuffer::get_font_width(),
+                   TextBuffer::get_font_height())
+    , _ropes_quad(TextureType::HUD, Renderer::EntityType::SCREEN_SPACE, TextBuffer::get_font_width(),
+                  TextBuffer::get_font_height())
+    , _bombs_quad(TextureType::HUD, Renderer::EntityType::SCREEN_SPACE, TextBuffer::get_font_width(),
+                  TextBuffer::get_font_height())
+    , _hold_item_quad(TextureType::HUD, Renderer::EntityType::SCREEN_SPACE, TextBuffer::get_font_width(),
+                      TextBuffer::get_font_height())
     , _text_buffer(nullptr)
     , _viewport(std::move(viewport))
 {
@@ -77,22 +82,22 @@ HUD::HUD(std::shared_ptr<Viewport> viewport)
     _bombs_quad.frame_changed<HUDSpritesheetFrames>(HUDSpritesheetFrames::BOMB_ICON);
     _hold_item_quad.frame_changed<HUDSpritesheetFrames>(HUDSpritesheetFrames::HOLD_ITEM_ICON);
 
-    icons_offset_pixels = _viewport->get_width() * 0.1f;
+    const float ICONS_OFFSET_WORLD_UNITS = TextBuffer::get_font_width() * 3.0f;
     
-    const auto pos_x = static_cast<float>(_viewport->get_width() * 0.05f);
-    const auto pos_y = static_cast<float>(_viewport->get_height() * 0.05f);
-    
-    _heart_center.x = pos_x + (icons_offset_pixels * 0);
-    _bombs_center.x = pos_x + (icons_offset_pixels * 1);
-    _ropes_center.x = pos_x + (icons_offset_pixels * 2);
-    _dollar_center.x = pos_x + (icons_offset_pixels * 3);
-    _hold_item_center.x = pos_x + (icons_offset_pixels * 4);
+    const auto POS_X = static_cast<float>(_viewport->get_width_world_units() * 0.05f);
+    const auto POS_Y = static_cast<float>(_viewport->get_height_world_units() * 0.05f);
 
-    _heart_center.y = pos_y;
-    _dollar_center.y = pos_y;
-    _ropes_center.y = pos_y;
-    _bombs_center.y = pos_y;
-    _hold_item_center.y = pos_y;
+    _heart_center.x = POS_X + (ICONS_OFFSET_WORLD_UNITS * 0);
+    _bombs_center.x = POS_X + (ICONS_OFFSET_WORLD_UNITS * 1);
+    _ropes_center.x = POS_X + (ICONS_OFFSET_WORLD_UNITS * 2);
+    _dollar_center.x = POS_X + (ICONS_OFFSET_WORLD_UNITS * 3);
+    _hold_item_center.x = POS_X + (ICONS_OFFSET_WORLD_UNITS * 4);
+
+    _heart_center.y = POS_Y;
+    _dollar_center.y = POS_Y;
+    _ropes_center.y = POS_Y;
+    _bombs_center.y = POS_Y;
+    _hold_item_center.y = POS_Y;
 }
 
 HUD::~HUD()

--- a/src/game-loop/src/game-objects/PausePlayingGame.cpp
+++ b/src/game-loop/src/game-objects/PausePlayingGame.cpp
@@ -30,27 +30,28 @@ void PausePlayingGame::update(uint32_t delta_time_ms)
             _half_opaque_quad = std::make_shared<QuadComponent>(
                     TextureType::HUD,
                     Renderer::EntityType::SCREEN_SPACE,
-                    _viewport->get_width(),
-                    _viewport->get_height());
+                    _viewport->get_width_world_units(),
+                    _viewport->get_height_world_units());
 
             _half_opaque_quad->frame_changed<HUDSpritesheetFrames>(HUDSpritesheetFrames::HALF_OPAQUE_TILE);
-            _half_opaque_quad->update(_viewport->get_width() / 2.0f, _viewport->get_height() / 2.0f);
+            _half_opaque_quad->update(_viewport->get_width_world_units() / 2.0f, _viewport->get_height_world_units() / 2.0f);
 
             _text_entity_ids.paused = _text_buffer->create_text();
             _text_entity_ids.controls = _text_buffer->create_text();
 
             {
-                const float text_width = std::strlen(PAUSED_MSG) * 16.0f;
-                const float text_center_x = (_viewport->get_width() / 2.0f) - (text_width / 2.0f) + (16.0f / 2);
-                const float text_center_y = _viewport->get_height() * 0.8f;
+                const float text_width = std::strlen(PAUSED_MSG) * TextBuffer::get_font_width();
+                const float text_center_x = (_viewport->get_width_world_units() / 2.0f) - (text_width / 2.0f) + (TextBuffer::get_font_width() / 2.0f);
+                const float text_center_y = _viewport->get_height_world_units() * 0.8f;
 
                 _text_buffer->update_text(_text_entity_ids.paused, {text_center_x, text_center_y}, PAUSED_MSG, std::strlen(PAUSED_MSG));
             }
 
             {
-                const float text_width = std::strlen(Input::get_controls_msg()) * 16.0f;
-                const float text_center_x = (_viewport->get_width() / 2.0f) - (text_width / 2.0f) + (16.0f / 2);
-                const float text_center_y = _viewport->get_height() * 0.9f;
+                const float text_width = std::strlen(Input::get_controls_msg()) *
+                        TextBuffer::get_font_width();
+                const float text_center_x = (_viewport->get_width_world_units() / 2.0f) - (text_width / 2.0f) + (TextBuffer::get_font_width() / 2.0f);
+                const float text_center_y = _viewport->get_height_world_units() * 0.9f;
 
                 _text_buffer->update_text(_text_entity_ids.controls, {text_center_x, text_center_y}, Input::get_controls_msg(), std::strlen(Input::get_controls_msg()));
             }

--- a/src/game-loop/src/game-objects/TextBuffer.cpp
+++ b/src/game-loop/src/game-objects/TextBuffer.cpp
@@ -30,7 +30,8 @@ void TextBuffer::update_text(TextEntityID id, Point2D position, const char *cont
         // Resize text if it won't fit full length of new contents:
         while (it->quads.size() < length)
         {
-            it->quads.emplace_back(TextureType::FONT, Renderer::EntityType::SCREEN_SPACE, FONT_WIDTH_PIXELS, FONT_HEIGHT_PIXELS);
+            it->quads.emplace_back(TextureType::FONT, Renderer::EntityType::SCREEN_SPACE,
+                                   TextBuffer::get_font_width(), TextBuffer::get_font_height());
         }
 
         for (std::size_t index = 0; index < it->quads.size(); index++)
@@ -69,7 +70,7 @@ void TextBuffer::update_text(TextEntityID id, Point2D position, const char *cont
 
             // Update position:
 
-            quad.update(position.x + (index * OFFSET_PIXELS), position.y);
+            quad.update(position.x + (index * TextBuffer::get_font_offset()), position.y);
         }
     }
     else

--- a/src/video/src/Context_PSP.cpp
+++ b/src/video/src/Context_PSP.cpp
@@ -39,8 +39,8 @@ bool Video::setup_gl()
     SDL_GL_SetAttribute( SDL_GL_DOUBLEBUFFER, 1 );
 
     //  Create a window
-    auto surface = SDL_SetVideoMode(_viewport->get_width(),
-                                    _viewport->get_height(),
+    auto surface = SDL_SetVideoMode(_viewport->get_width_pixels(),
+                                    _viewport->get_height_pixels(),
                                     0, // current display's bpp
                                     SDL_DOUBLEBUF | SDL_OPENGL | SDL_SWSURFACE);
 

--- a/src/viewport/interface/viewport/Viewport.hpp
+++ b/src/viewport/interface/viewport/Viewport.hpp
@@ -2,6 +2,9 @@
 
 #include <cstdint>
 
+using WorldUnit_t = float;
+using Pixel_t = uint16_t;
+
 class Viewport final
 {
 public:
@@ -12,13 +15,31 @@ public:
         , _aspect(static_cast<float>(_width) / _height)
     { }
 
-    uint16_t get_width() const { return _width; }
-    uint16_t get_height() const { return _height; }
     float get_aspect() const { return _aspect; }
+
+    Pixel_t get_width_pixels() const { return _width; }
+    Pixel_t get_height_pixels() const { return _height; }
+
+    WorldUnit_t get_width_world_units() const { return _SCREEN_WIDTH_IN_TILES; }
+    WorldUnit_t get_height_world_units() const { return calculate_coefficient_world_units() * 2.0f;}
+
+    WorldUnit_t world_units_to_pixels(Pixel_t pixels) const
+    {
+        // Tiles are used as the basis for pixel to world-unit conversion.
+        // 1 world unit is equal to 1 tile width/height.
+        return static_cast<float>(_width) / _SCREEN_WIDTH_IN_TILES;
+    }
+
+    // Returns coefficient to glOrtho of such value,
+    // so screen with dimensions of screen_width_tiles would entirely fit on the screen.
+    float calculate_coefficient_world_units() const { return (get_width_world_units() / get_aspect()) / 2.0f; }
+    // Same but using pixels as the base camera unit.
+    float calculate_coefficient_pixels() const { return (get_width_pixels() / get_aspect()) / 2.0f; }
 
 private:
 
     const uint16_t _width;
     const uint16_t _height;
     const float _aspect;
+    const std::size_t _SCREEN_WIDTH_IN_TILES = 20;
 };


### PR DESCRIPTION
So far rendering HUD and pause screen was fine as long as the resolution was fixed to 480x272 (PSP's native).
However, when running fullscreen on desktop, screen-space quads become extremely small:

![image](https://user-images.githubusercontent.com/13459304/87853637-0e9a3880-c90c-11ea-94f1-37293787b98f.png)

This PR re-defines screen-space quads' dimensions in terms of world units, rather than in pixels.
World units depend on the screen resolution (to keep the same number of tiles rendered on the screen on every device), meaning they are more portable way of defining size.

![image](https://user-images.githubusercontent.com/13459304/87853658-325d7e80-c90c-11ea-9004-4c82f7abe794.png)
