### PR TITLE
Renamed GameObject to GameEntity

### DIFF
--- a/src/game-loop/CMakeLists.txt
+++ b/src/game-loop/CMakeLists.txt
@@ -39,7 +39,7 @@ add_library(GameLoop STATIC
         interface/GameLoopLevelSummaryState.hpp
         interface/GameLoopScoresState.hpp
         include/main-dude/MainDude.hpp
-        include/game-objects/GameObject.hpp
+        include/game-objects/GameEntity.hpp
         include/game-objects/MainLogo.hpp
         include/game-objects/QuitSign.hpp
         include/game-objects/ResetSign.hpp

--- a/src/game-loop/include/game-objects/CopyrightsSign.hpp
+++ b/src/game-loop/include/game-objects/CopyrightsSign.hpp
@@ -2,10 +2,10 @@
 
 #include "spritesheet-frames/MainMenuSpritesheetFrames.hpp"
 #include "components/QuadComponent.hpp"
-#include "GameObject.hpp"
+#include "GameEntity.hpp"
 #include "Point2D.hpp"
 
-class CopyrightsSign : public GameObject
+class CopyrightsSign : public GameEntity
 {
 public:
 

--- a/src/game-loop/include/game-objects/DeathOverlay.hpp
+++ b/src/game-loop/include/game-objects/DeathOverlay.hpp
@@ -3,13 +3,13 @@
 #include <memory>
 #include <string>
 
-#include "GameObject.hpp"
+#include "GameEntity.hpp"
 #include "components/QuadComponent.hpp"
 #include "Point2D.hpp"
 #include "TextBuffer.hpp"
 #include "viewport/Viewport.hpp"
 
-class DeathOverlay : public GameObject
+class DeathOverlay : public GameEntity
 {
 public:
 

--- a/src/game-loop/include/game-objects/GameEntity.hpp
+++ b/src/game-loop/include/game-objects/GameEntity.hpp
@@ -2,10 +2,10 @@
 
 #include <cstdint>
 
-class GameObject
+class GameEntity
 {
 public:
-    virtual ~GameObject() = default;
+    virtual ~GameEntity() = default;
     virtual void update(uint32_t delta_time_ms) = 0;
     bool is_marked_for_disposal() const { return _to_dispose; }
 protected:

--- a/src/game-loop/include/game-objects/HUD.hpp
+++ b/src/game-loop/include/game-objects/HUD.hpp
@@ -2,13 +2,13 @@
 
 #include <memory>
 
-#include "GameObject.hpp"
+#include "GameEntity.hpp"
 #include "components/QuadComponent.hpp"
 #include "Point2D.hpp"
 #include "TextBuffer.hpp"
 #include "viewport/Viewport.hpp"
 
-class HUD : public GameObject
+class HUD : public GameEntity
 {
 public:
 

--- a/src/game-loop/include/game-objects/MainLogo.hpp
+++ b/src/game-loop/include/game-objects/MainLogo.hpp
@@ -2,10 +2,10 @@
 
 #include "spritesheet-frames/MainMenuSpritesheetFrames.hpp"
 #include "components/QuadComponent.hpp"
-#include "GameObject.hpp"
+#include "GameEntity.hpp"
 #include "Point2D.hpp"
 
-class MainLogo : public GameObject
+class MainLogo : public GameEntity
 {
 public:
 

--- a/src/game-loop/include/game-objects/PauseOverlay.hpp
+++ b/src/game-loop/include/game-objects/PauseOverlay.hpp
@@ -3,13 +3,13 @@
 #include <memory>
 #include <string>
 
-#include "GameObject.hpp"
+#include "GameEntity.hpp"
 #include "components/QuadComponent.hpp"
 #include "Point2D.hpp"
 #include "TextBuffer.hpp"
 #include "viewport/Viewport.hpp"
 
-class PauseOverlay : public GameObject
+class PauseOverlay : public GameEntity
 {
 public:
 

--- a/src/game-loop/include/game-objects/QuitSign.hpp
+++ b/src/game-loop/include/game-objects/QuitSign.hpp
@@ -2,10 +2,10 @@
 
 #include "spritesheet-frames/MainMenuSpritesheetFrames.hpp"
 #include "components/QuadComponent.hpp"
-#include "GameObject.hpp"
+#include "GameEntity.hpp"
 #include "Point2D.hpp"
 
-class QuitSign : public GameObject
+class QuitSign : public GameEntity
 {
 public:
 

--- a/src/game-loop/include/game-objects/ResetSign.hpp
+++ b/src/game-loop/include/game-objects/ResetSign.hpp
@@ -2,10 +2,10 @@
 
 #include "spritesheet-frames/MainMenuSpritesheetFrames.hpp"
 #include "components/QuadComponent.hpp"
-#include "GameObject.hpp"
+#include "GameEntity.hpp"
 #include "Point2D.hpp"
 
-class ResetSign : public GameObject
+class ResetSign : public GameEntity
 {
 public:
 

--- a/src/game-loop/include/game-objects/ScoresSign.hpp
+++ b/src/game-loop/include/game-objects/ScoresSign.hpp
@@ -2,10 +2,10 @@
 
 #include "spritesheet-frames/MainMenuSpritesheetFrames.hpp"
 #include "components/QuadComponent.hpp"
-#include "GameObject.hpp"
+#include "GameEntity.hpp"
 #include "Point2D.hpp"
 
-class ScoresSign : public GameObject
+class ScoresSign : public GameEntity
 {
 public:
 

--- a/src/game-loop/include/game-objects/StartSign.hpp
+++ b/src/game-loop/include/game-objects/StartSign.hpp
@@ -2,10 +2,10 @@
 
 #include "spritesheet-frames/MainMenuSpritesheetFrames.hpp"
 #include "components/QuadComponent.hpp"
-#include "GameObject.hpp"
+#include "GameEntity.hpp"
 #include "Point2D.hpp"
 
-class StartSign : public GameObject
+class StartSign : public GameEntity
 {
 public:
 

--- a/src/game-loop/include/game-objects/TextBuffer.hpp
+++ b/src/game-loop/include/game-objects/TextBuffer.hpp
@@ -6,12 +6,12 @@
 #include "viewport/Viewport.hpp"
 #include "spritesheet-frames/FontSpritesheetFrames.hpp"
 #include "components/QuadComponent.hpp"
-#include "GameObject.hpp"
+#include "GameEntity.hpp"
 #include "Point2D.hpp"
 
 using TextEntityID = std::uint16_t;
 
-class TextBuffer : public GameObject
+class TextBuffer : public GameEntity
 {
 public:
 

--- a/src/game-loop/include/game-objects/TutorialSign.hpp
+++ b/src/game-loop/include/game-objects/TutorialSign.hpp
@@ -2,10 +2,10 @@
 
 #include "spritesheet-frames/MainMenuSpritesheetFrames.hpp"
 #include "components/QuadComponent.hpp"
-#include "GameObject.hpp"
+#include "GameEntity.hpp"
 #include "Point2D.hpp"
 
-class TutorialSign : public GameObject
+class TutorialSign : public GameEntity
 {
 public:
 

--- a/src/game-loop/include/main-dude/MainDude.hpp
+++ b/src/game-loop/include/main-dude/MainDude.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "RenderEntity.hpp"
-#include "game-objects/GameObject.hpp"
+#include "game-objects/GameEntity.hpp"
 #include "spritesheet-frames/MainDudeSpritesheetFrames.hpp"
 
 #include "components/PhysicsComponent.hpp"
@@ -34,7 +34,7 @@ class MainDudeBaseState;
 class Input;
 class MapTile;
 
-class MainDude : public GameObject
+class MainDude : public GameEntity
 {
 public:
 

--- a/src/game-loop/interface/GameLoop.hpp
+++ b/src/game-loop/interface/GameLoop.hpp
@@ -16,7 +16,7 @@
 #include "GameLoopStartedState.hpp"
 #include "GameLoopScoresState.hpp"
 
-class GameObject;
+class GameEntity;
 class MainDude;
 class TextBuffer;
 class Viewport;
@@ -56,6 +56,6 @@ private:
     std::shared_ptr<Viewport> _viewport;
     std::shared_ptr<TextBuffer> _text_buffer;
     std::shared_ptr<MainDude> _main_dude;
-    std::vector<std::shared_ptr<GameObject>> _game_objects;
+    std::vector<std::shared_ptr<GameEntity>> _game_objects;
     std::function<bool(uint32_t delta_time_ms)> _loop;
 };

--- a/src/game-loop/src/game-loop/GameLoopPlayingState.cpp
+++ b/src/game-loop/src/game-loop/GameLoopPlayingState.cpp
@@ -7,7 +7,7 @@
 #include "ModelViewCamera.hpp"
 #include "ScreenSpaceCamera.hpp"
 #include "GameLoopPlayingState.hpp"
-#include "game-objects/GameObject.hpp"
+#include "game-objects/GameEntity.hpp"
 #include "game-objects/HUD.hpp"
 #include "game-objects/TextBuffer.hpp"
 #include "game-objects/PauseOverlay.hpp"


### PR DESCRIPTION
`GameEntity` fits more to the terminology used within the project, i.e there's already a `RenderEntity`, and as former `GameObject`-s are composed out of `Component`-s, it would fit more to the idea of the [entity-component-system](https://en.wikipedia.org/wiki/Entity_component_system).