### PR TITLE
Added optional font scaling to the TextBuffer API.

### DIFF
--- a/src/game-loop/include/game-entities/TextBuffer.hpp
+++ b/src/game-loop/include/game-entities/TextBuffer.hpp
@@ -23,7 +23,7 @@ public:
     void update(uint32_t delta_time_ms) override;
     TextEntityID create_text();
     void remove_text(TextEntityID id) { _for_removal.push_back(id); }
-    void update_text(TextEntityID id, Point2D position, const char* contents, std::size_t length, bool yellow=false);
+    void update_text(TextEntityID id, Point2D position, const char* contents, std::size_t length, float scale = 1.0f, bool yellow=false);
 
 private:
 

--- a/src/game-loop/src/game-entities/DeathOverlay.cpp
+++ b/src/game-loop/src/game-entities/DeathOverlay.cpp
@@ -28,11 +28,12 @@ void DeathOverlay::launch()
     _text_entity_ids.controls = _text_buffer->create_text();
 
     {
-        const float text_width = std::strlen(GAME_OVER_MSG) * TextBuffer::get_font_width();
+        const float scale = 2.0f;
+        const float text_width = std::strlen(GAME_OVER_MSG) * TextBuffer::get_font_width() * scale;
         const float text_center_x = (_viewport->get_width_world_units() / 2.0f) - (text_width / 2.0f) + (TextBuffer::get_font_width() / 2.0f);
         const float text_center_y = _viewport->get_height_world_units() * 0.25f;
 
-        _text_buffer->update_text(_text_entity_ids.game_over, {text_center_x, text_center_y}, GAME_OVER_MSG, std::strlen(GAME_OVER_MSG), true);
+        _text_buffer->update_text(_text_entity_ids.game_over, {text_center_x, text_center_y}, GAME_OVER_MSG, std::strlen(GAME_OVER_MSG), scale, true);
     }
 
     {
@@ -43,7 +44,7 @@ void DeathOverlay::launch()
         const float text_center_x = (_viewport->get_width_world_units() / 2.0f) - (text_width / 2.0f) + (TextBuffer::get_font_width() / 2.0f);
         const float text_center_y = _viewport->get_height_world_units() * 0.45f;
 
-        _text_buffer->update_text(_text_entity_ids.controls, {text_center_x, text_center_y}, available_controls_cstr, std::strlen(available_controls_cstr), true);
+        _text_buffer->update_text(_text_entity_ids.controls, {text_center_x, text_center_y}, available_controls_cstr, std::strlen(available_controls_cstr), 1.0f, true);
     }
 }
 

--- a/src/game-loop/src/game-entities/PauseOverlay.cpp
+++ b/src/game-loop/src/game-entities/PauseOverlay.cpp
@@ -46,11 +46,12 @@ void PauseOverlay::update(uint32_t delta_time_ms)
             _text_entity_ids.controls = _text_buffer->create_text();
 
             {
-                const float text_width = std::strlen(PAUSED_MSG) * TextBuffer::get_font_width();
+                const float scale = 2.0f;
+                const float text_width = std::strlen(PAUSED_MSG) * TextBuffer::get_font_width() * scale;
                 const float text_center_x = (_viewport->get_width_world_units() / 2.0f) - (text_width / 2.0f) + (TextBuffer::get_font_width() / 2.0f);
                 const float text_center_y = _viewport->get_height_world_units() * 0.8f;
 
-                _text_buffer->update_text(_text_entity_ids.paused, {text_center_x, text_center_y}, PAUSED_MSG, std::strlen(PAUSED_MSG));
+                _text_buffer->update_text(_text_entity_ids.paused, {text_center_x, text_center_y}, PAUSED_MSG, std::strlen(PAUSED_MSG), scale);
             }
 
             {

--- a/src/game-loop/src/game-entities/TextBuffer.cpp
+++ b/src/game-loop/src/game-entities/TextBuffer.cpp
@@ -22,7 +22,7 @@ TextEntityID TextBuffer::create_text()
     return unique_id_pool;
 }
 
-void TextBuffer::update_text(TextEntityID id, Point2D position, const char *contents, std::size_t length, bool yellow)
+void TextBuffer::update_text(TextEntityID id, Point2D position, const char *contents, std::size_t length, float scale, bool yellow)
 {
     auto it = std::find_if(_text_entries.begin(), _text_entries.end(), [id](const TextEntity& e) { return e.id == id; });
     if (it != _text_entries.end())
@@ -31,7 +31,7 @@ void TextBuffer::update_text(TextEntityID id, Point2D position, const char *cont
         while (it->quads.size() < length)
         {
             it->quads.emplace_back(TextureType::FONT, Renderer::EntityType::SCREEN_SPACE,
-                                   TextBuffer::get_font_width(), TextBuffer::get_font_height());
+                                   TextBuffer::get_font_width() * scale, TextBuffer::get_font_height() * scale);
         }
 
         for (std::size_t index = 0; index < it->quads.size(); index++)
@@ -70,7 +70,7 @@ void TextBuffer::update_text(TextEntityID id, Point2D position, const char *cont
 
             // Update position:
 
-            quad.update(position.x + (index * TextBuffer::get_font_offset()), position.y);
+            quad.update(position.x + (index * TextBuffer::get_font_offset() * scale), position.y);
         }
     }
     else


### PR DESCRIPTION
As in the title.
Applied in the `PauseOverlay`:

![image](https://user-images.githubusercontent.com/13459304/89787124-423c3d00-db1d-11ea-8806-1394071d896d.png)

While tinkering with the `TextBuffer` with this and other MR's (https://github.com/dbeef/spelunky-psp/pull/56, https://github.com/dbeef/spelunky-psp/pull/58) I came into conclusion that the text rendering API must be re-worked, as it is very much a C-style API, verbose with its syntax. Something more RAII-like would fit better as after all, this is a C++ 14 project.