### PR TITLE
Observer pattern

### DIFF
--- a/src/game-loop/CMakeLists.txt
+++ b/src/game-loop/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(GameLoop STATIC
         interface/GameLoopLevelSummaryState.hpp
         interface/GameLoopScoresState.hpp
         include/main-dude/MainDude.hpp
+        include/main-dude/MainDudeEvent.hpp
         include/game-entities/GameEntity.hpp
         include/game-entities/MainLogo.hpp
         include/game-entities/QuitSign.hpp
@@ -97,4 +98,5 @@ target_link_libraries(GameLoop
         Renderer
         Collisions
         Level
+        Patterns
 )

--- a/src/game-loop/include/game-entities/HUD.hpp
+++ b/src/game-loop/include/game-entities/HUD.hpp
@@ -7,19 +7,20 @@
 #include "components/QuadComponent.hpp"
 #include "Point2D.hpp"
 #include "viewport/Viewport.hpp"
+#include "patterns/Observer.hpp"
+#include "main-dude/MainDudeEvent.hpp"
 
-class HUD : public GameEntity
+class MainDude;
+
+class HUD : public GameEntity, public Observer<MainDudeEvent>
 {
 public:
 
-    explicit HUD(std::shared_ptr<Viewport>);
+    HUD(std::shared_ptr<Viewport>, std::shared_ptr<MainDude> main_dude);
+    ~HUD() override;
 
     void update(uint32_t delta_time_ms) override;
-
-    void set_hearts_count(uint32_t hearts);
-    void set_ropes_count(uint32_t ropes);
-    void set_bombs_count(uint32_t bombs);
-    void set_dollars_count(uint32_t dollars);
+    void on_notify(MainDudeEvent) override;
 
 private:
 
@@ -27,6 +28,7 @@ private:
     static constexpr float ICON_SIZE_WORLD_UNITS = 0.5f;
 
     std::shared_ptr<Viewport> _viewport;
+    std::shared_ptr<MainDude> _main_dude;
 
     struct
     {

--- a/src/game-loop/include/main-dude/MainDude.hpp
+++ b/src/game-loop/include/main-dude/MainDude.hpp
@@ -3,6 +3,7 @@
 #include "RenderEntity.hpp"
 #include "game-entities/GameEntity.hpp"
 #include "spritesheet-frames/MainDudeSpritesheetFrames.hpp"
+#include "patterns/Subject.hpp"
 
 #include "components/PhysicsComponent.hpp"
 #include "components/QuadComponent.hpp"
@@ -27,6 +28,7 @@
 #include "main-dude/states/MainDudeRunningLookingUpState.hpp"
 #include "main-dude/states/MainDudeDeadState.hpp"
 #include "main-dude/states/MainDudeStunnedState.hpp"
+#include "main-dude/MainDudeEvent.hpp"
 
 #include <vector>
 
@@ -34,15 +36,21 @@ class MainDudeBaseState;
 class Input;
 class MapTile;
 
-class MainDude : public GameEntity
+class MainDude : public GameEntity, public Subject<MainDudeEvent>
 {
 public:
 
     MainDude(float x_pos_center, float y_pos_center);
+
     void update(uint32_t delta_time_ms) override;
 
     float get_x_pos_center() const { return _physics.get_x_position(); }
     float get_y_pos_center() const { return _physics.get_y_position(); }
+
+    uint8_t get_hearts() const { return _stats.hearts; }
+    uint8_t get_dollars() const { return _stats.dollars; }
+    uint8_t get_ropes() const { return _stats.ropes; }
+    uint8_t get_bombs() const { return _stats.bombs; }
 
     void set_position_on_tile(MapTile* map_tile);
     void enter_level_summary_state();
@@ -52,6 +60,7 @@ public:
 
 private:
 
+    void decrease_hearts(uint8_t amount);
     void handle_input(const Input& input);
     MapTile* is_overlaping_tile(MapTileType) const;
 
@@ -102,6 +111,14 @@ private:
         MainDudeDeadState dead;
         MainDudeStunnedState stunned;
     } _states;
+
+    struct
+    {
+        int16_t hearts = 4;
+        int16_t ropes = 4;
+        int16_t bombs = 4;
+        int16_t dollars = 0;
+    } _stats;
 
     struct
     {

--- a/src/game-loop/include/main-dude/MainDudeEvent.hpp
+++ b/src/game-loop/include/main-dude/MainDudeEvent.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+enum class MainDudeEvent
+{
+    HEARTS_COUNT_CHANGED,
+};

--- a/src/game-loop/src/game-entities/HUD.cpp
+++ b/src/game-loop/src/game-entities/HUD.cpp
@@ -4,6 +4,7 @@
 
 #include "game-entities/HUD.hpp"
 #include "spritesheet-frames/HUDSpritesheetFrames.hpp"
+#include "main-dude/MainDude.hpp"
 
 namespace
 {
@@ -21,28 +22,13 @@ void HUD::update(uint32_t delta_time_ms)
     // Nothing to update.
 }
 
-void HUD::set_hearts_count(uint32_t hearts)
+HUD::HUD(std::shared_ptr<Viewport> viewport, std::shared_ptr<MainDude> main_dude)
+    : _viewport(std::move(viewport))
+    , _main_dude(std::move(main_dude))
 {
-    _texts.hearts.set_text(to_string(hearts));
-}
+    assert(_viewport);
+    assert(_main_dude);
 
-void HUD::set_ropes_count(uint32_t ropes)
-{
-    _texts.ropes.set_text(to_string(ropes));
-}
-
-void HUD::set_bombs_count(uint32_t bombs)
-{
-    _texts.bombs.set_text(to_string(bombs));
-}
-
-void HUD::set_dollars_count(uint32_t dollars)
-{
-    _texts.dollars.set_text(to_string(dollars));
-}
-
-HUD::HUD(std::shared_ptr<Viewport> viewport) : _viewport(std::move(viewport))
-{
     _quads.heart.frame_changed<HUDSpritesheetFrames>(HUDSpritesheetFrames::HEART);
     _quads.dollar.frame_changed<HUDSpritesheetFrames>(HUDSpritesheetFrames::DOLLAR_SIGN);
     _quads.ropes.frame_changed<HUDSpritesheetFrames>(HUDSpritesheetFrames::ROPE_ICON);
@@ -68,4 +54,25 @@ HUD::HUD(std::shared_ptr<Viewport> viewport) : _viewport(std::move(viewport))
     _texts.ropes.set_position({ropes_center.x + ICON_SIZE_WORLD_UNITS, ropes_center.y});
     _texts.bombs.set_position({bombs_center.x + ICON_SIZE_WORLD_UNITS, bombs_center.y});
     _texts.dollars.set_position({dollar_center.x + ICON_SIZE_WORLD_UNITS, dollar_center.y});
+
+    _texts.hearts.set_text(to_string(_main_dude->get_hearts()));
+    _texts.ropes.set_text(to_string(_main_dude->get_ropes()));
+    _texts.bombs.set_text(to_string(_main_dude->get_bombs()));
+    _texts.dollars.set_text(to_string(_main_dude->get_dollars()));
+
+    _main_dude->add_observer(this);
+}
+
+void HUD::on_notify(MainDudeEvent event)
+{
+    switch(event)
+    {
+        case MainDudeEvent::HEARTS_COUNT_CHANGED: _texts.hearts.set_text(to_string(_main_dude->get_hearts())); break;
+        default: assert(false); break;
+    }
+}
+
+HUD::~HUD()
+{
+    _main_dude->remove_observer(this);
 }

--- a/src/game-loop/src/game-loop/GameLoopPlayingState.cpp
+++ b/src/game-loop/src/game-loop/GameLoopPlayingState.cpp
@@ -121,13 +121,8 @@ void GameLoopPlayingState::enter(GameLoop& game_loop)
 
     // Create HUD:
 
-    auto hud = std::make_shared<HUD>(game_loop._viewport);
+    auto hud = std::make_shared<HUD>(game_loop._viewport, game_loop._main_dude);
     game_loop._game_objects.push_back(hud);
-
-    hud->set_bombs_count(4);
-    hud->set_dollars_count(0);
-    hud->set_hearts_count(4);
-    hud->set_ropes_count(4);
 
     // Create pause overlay:
 

--- a/src/game-loop/src/main-dude/MainDude.cpp
+++ b/src/game-loop/src/main-dude/MainDude.cpp
@@ -179,3 +179,9 @@ bool MainDude::hang_off_cliff_left()
 
     return false;
 }
+
+void MainDude::decrease_hearts(uint8_t amount)
+{
+    _stats.hearts = std::max<int16_t>(0, _stats.hearts - amount);
+    notify(MainDudeEvent::HEARTS_COUNT_CHANGED);
+}

--- a/src/game-loop/src/main-dude/states/MainDudeStunnedState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeStunnedState.cpp
@@ -9,7 +9,7 @@ namespace
 
 void MainDudeStunnedState::enter(MainDude &main_dude)
 {
-    // TODO: Notify all observers, once observer pattern is implemented.
+    main_dude.decrease_hearts(1);
     main_dude._physics.set_friction(PhysicsComponent::get_default_friction() * 1.8f);
     main_dude._animation.start(static_cast<std::size_t>(MainDudeSpritesheetFrames::STUNNED_0_FIRST),
                                static_cast<std::size_t>(MainDudeSpritesheetFrames::STUNNED_4_LAST),

--- a/src/patterns/interface/patterns/Observer.hpp
+++ b/src/patterns/interface/patterns/Observer.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <memory>
+
+template<class EventType>
+class Observer
+{
+public:
+    virtual void on_notify(EventType) = 0;
+    virtual ~Observer() = default;
+};

--- a/src/patterns/interface/patterns/Subject.hpp
+++ b/src/patterns/interface/patterns/Subject.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "Observer.hpp"
+
+#include <vector>
+#include <algorithm>
+
+template<class EventType>
+class Subject
+{
+public:
+
+    Subject()
+    {
+        const std::size_t DEFAULT_OBSERVERS_CAPACITY = 8;
+        _observers.reserve(DEFAULT_OBSERVERS_CAPACITY);
+    }
+
+    ~Subject() = default;
+
+    void add_observer(Observer<EventType>* observer)
+    {
+        _observers.emplace_back(observer);
+    }
+
+    void remove_observer(const Observer<EventType>* observer)
+    {
+        std::remove_if(_observers.begin(), _observers.end(), [observer](const auto& other){ return observer == other; });
+    }
+
+    void notify(EventType event)
+    {
+        for (auto& observer : _observers)
+        {
+            observer->on_notify(event);
+        }
+    }
+
+private:
+
+    std::vector<Observer<EventType>*> _observers;
+};


### PR DESCRIPTION
The observer pattern, as in Gang of Four's observer pattern.

Used to decouple updating HUD (and playing sounds in the future) from `MainDude` states.