### PR TITLE
Damage system

### DIFF
--- a/src/game-loop/CMakeLists.txt
+++ b/src/game-loop/CMakeLists.txt
@@ -90,6 +90,15 @@ add_library(GameLoop STATIC
         include/components/specialized/PauseOverlayComponent.hpp
         include/components/specialized/DeathOverlayComponent.hpp
         include/components/specialized/LevelSummaryOverlayComponent.hpp
+        include/components/damage/TakeFallDamageComponent.hpp
+        include/components/damage/HitpointComponent.hpp
+        include/components/damage/TakeProjectileDamageComponent.hpp
+        include/components/damage/GiveProjectileDamageComponent.hpp
+        include/components/damage/TakeMeleeDamageComponent.hpp
+        include/components/damage/GiveMeleeDamageComponent.hpp
+        include/components/damage/TakeTileCollisionDamageComponent.hpp
+        include/components/damage/TakeJumpOnTopDamage.hpp
+        include/components/damage/GiveJumpOnTopDamage.hpp
 
         # Prefabs:
 
@@ -130,6 +139,7 @@ add_library(GameLoop STATIC
         include/prefabs/particles/BonesParticle.hpp
         include/prefabs/particles/RopeCollectedParticle.hpp
         include/prefabs/particles/BombCollectedParticle.hpp
+        include/prefabs/particles/BloodParticle.hpp
         include/prefabs/collectibles/GoldNugget.hpp
         include/prefabs/collectibles/GoldChunk.hpp
         include/prefabs/collectibles/SmallGem.hpp
@@ -185,6 +195,7 @@ add_library(GameLoop STATIC
         src/prefabs/particles/RopeCollectedParticle.cpp
         src/prefabs/particles/BombCollectedParticle.cpp
         src/prefabs/particles/BonesParticle.cpp
+        src/prefabs/particles/BloodParticle.cpp
         src/prefabs/collectibles/GoldNugget.cpp
         src/prefabs/collectibles/GoldChunk.cpp
         src/prefabs/collectibles/SmallGem.cpp
@@ -225,6 +236,7 @@ add_library(GameLoop STATIC
         include/system/InputSystem.hpp
         include/system/DisposingSystem.hpp
         include/system/ItemSystem.hpp
+        include/system/DamageSystem.hpp
 
         src/system/ParticleSystem.cpp
         src/system/RenderingSystem.cpp
@@ -235,6 +247,7 @@ add_library(GameLoop STATIC
         src/system/InputSystem.cpp
         src/system/DisposingSystem.cpp
         src/system/ItemSystem.cpp
+        src/system/DamageSystem.cpp
 
         # Other:
 
@@ -247,7 +260,7 @@ add_library(GameLoop STATIC
         interface/other/Inventory.hpp
         interface/other/InventoryEvent.hpp
         include/other/LootCollectedEvent.hpp
-        include/system/DamageSystem.hpp src/system/DamageSystem.cpp include/components/damage/TakeFallDamageComponent.hpp include/components/damage/HitpointComponent.hpp include/components/damage/TakeProjectileDamageComponent.hpp include/components/damage/GiveProjectileDamageComponent.hpp include/prefabs/particles/BloodParticle.hpp src/prefabs/particles/BloodParticle.cpp include/components/damage/TakeMeleeDamageComponent.hpp include/components/damage/GiveMeleeDamageComponent.hpp include/components/damage/TakeTileCollisionDamageComponent.hpp include/components/damage/TakeJumpOnTopDamage.hpp include/components/damage/GiveJumpOnTopDamage.hpp)
+)
 
 target_include_directories(GameLoop
         PRIVATE include interface

--- a/src/game-loop/CMakeLists.txt
+++ b/src/game-loop/CMakeLists.txt
@@ -84,6 +84,7 @@ add_library(GameLoop STATIC
         include/components/generic/AnimationComponent.hpp
         include/components/generic/MeshComponent.hpp
         include/components/generic/ActivableComponent.hpp
+        include/components/generic/NpcTypeComponent.hpp
         include/components/specialized/MainDudeComponent.hpp
         include/components/specialized/LevelSummaryTracker.hpp
         include/components/specialized/HudOverlayComponent.hpp
@@ -260,7 +261,8 @@ add_library(GameLoop STATIC
         interface/other/Inventory.hpp
         interface/other/InventoryEvent.hpp
         include/other/LootCollectedEvent.hpp
-        include/other/NpcType.hpp include/components/generic/NpcTypeComponent.hpp)
+        include/other/NpcType.hpp
+)
 
 target_include_directories(GameLoop
         PRIVATE include interface

--- a/src/game-loop/CMakeLists.txt
+++ b/src/game-loop/CMakeLists.txt
@@ -260,7 +260,7 @@ add_library(GameLoop STATIC
         interface/other/Inventory.hpp
         interface/other/InventoryEvent.hpp
         include/other/LootCollectedEvent.hpp
-)
+        include/other/NpcType.hpp include/components/generic/NpcTypeComponent.hpp)
 
 target_include_directories(GameLoop
         PRIVATE include interface

--- a/src/game-loop/CMakeLists.txt
+++ b/src/game-loop/CMakeLists.txt
@@ -247,7 +247,7 @@ add_library(GameLoop STATIC
         interface/other/Inventory.hpp
         interface/other/InventoryEvent.hpp
         include/other/LootCollectedEvent.hpp
-        include/system/DamageSystem.hpp src/system/DamageSystem.cpp include/components/damage/TakeFallDamageComponent.hpp include/components/damage/HitpointComponent.hpp include/components/damage/TakeProjectileDamageComponent.hpp include/components/damage/GiveProjectileDamageComponent.hpp include/prefabs/particles/BloodParticle.hpp src/prefabs/particles/BloodParticle.cpp include/components/damage/TakeMeleeDamageComponent.hpp include/components/damage/GiveMeleeDamageComponent.hpp)
+        include/system/DamageSystem.hpp src/system/DamageSystem.cpp include/components/damage/TakeFallDamageComponent.hpp include/components/damage/HitpointComponent.hpp include/components/damage/TakeProjectileDamageComponent.hpp include/components/damage/GiveProjectileDamageComponent.hpp include/prefabs/particles/BloodParticle.hpp src/prefabs/particles/BloodParticle.cpp include/components/damage/TakeMeleeDamageComponent.hpp include/components/damage/GiveMeleeDamageComponent.hpp include/components/damage/TakeTileCollisionDamageComponent.hpp)
 
 target_include_directories(GameLoop
         PRIVATE include interface

--- a/src/game-loop/CMakeLists.txt
+++ b/src/game-loop/CMakeLists.txt
@@ -247,7 +247,7 @@ add_library(GameLoop STATIC
         interface/other/Inventory.hpp
         interface/other/InventoryEvent.hpp
         include/other/LootCollectedEvent.hpp
-        include/system/DamageSystem.hpp src/system/DamageSystem.cpp include/components/damage/TakeFallDamageComponent.hpp include/components/damage/HitpointComponent.hpp include/components/damage/TakeProjectileDamageComponent.hpp include/components/damage/GiveProjectileDamageComponent.hpp include/prefabs/particles/BloodParticle.hpp src/prefabs/particles/BloodParticle.cpp)
+        include/system/DamageSystem.hpp src/system/DamageSystem.cpp include/components/damage/TakeFallDamageComponent.hpp include/components/damage/HitpointComponent.hpp include/components/damage/TakeProjectileDamageComponent.hpp include/components/damage/GiveProjectileDamageComponent.hpp include/prefabs/particles/BloodParticle.hpp src/prefabs/particles/BloodParticle.cpp include/components/damage/TakeMeleeDamageComponent.hpp include/components/damage/GiveMeleeDamageComponent.hpp)
 
 target_include_directories(GameLoop
         PRIVATE include interface

--- a/src/game-loop/CMakeLists.txt
+++ b/src/game-loop/CMakeLists.txt
@@ -247,7 +247,7 @@ add_library(GameLoop STATIC
         interface/other/Inventory.hpp
         interface/other/InventoryEvent.hpp
         include/other/LootCollectedEvent.hpp
-        include/system/DamageSystem.hpp src/system/DamageSystem.cpp include/components/damage/TakeFallDamageComponent.hpp include/components/damage/HitpointComponent.hpp)
+        include/system/DamageSystem.hpp src/system/DamageSystem.cpp include/components/damage/TakeFallDamageComponent.hpp include/components/damage/HitpointComponent.hpp include/components/damage/TakeProjectileDamageComponent.hpp include/components/damage/GiveProjectileDamageComponent.hpp include/prefabs/particles/BloodParticle.hpp src/prefabs/particles/BloodParticle.cpp)
 
 target_include_directories(GameLoop
         PRIVATE include interface

--- a/src/game-loop/CMakeLists.txt
+++ b/src/game-loop/CMakeLists.txt
@@ -247,7 +247,7 @@ add_library(GameLoop STATIC
         interface/other/Inventory.hpp
         interface/other/InventoryEvent.hpp
         include/other/LootCollectedEvent.hpp
-        include/system/DamageSystem.hpp src/system/DamageSystem.cpp include/components/damage/TakeFallDamageComponent.hpp include/components/damage/HitpointComponent.hpp include/components/damage/TakeProjectileDamageComponent.hpp include/components/damage/GiveProjectileDamageComponent.hpp include/prefabs/particles/BloodParticle.hpp src/prefabs/particles/BloodParticle.cpp include/components/damage/TakeMeleeDamageComponent.hpp include/components/damage/GiveMeleeDamageComponent.hpp include/components/damage/TakeTileCollisionDamageComponent.hpp)
+        include/system/DamageSystem.hpp src/system/DamageSystem.cpp include/components/damage/TakeFallDamageComponent.hpp include/components/damage/HitpointComponent.hpp include/components/damage/TakeProjectileDamageComponent.hpp include/components/damage/GiveProjectileDamageComponent.hpp include/prefabs/particles/BloodParticle.hpp src/prefabs/particles/BloodParticle.cpp include/components/damage/TakeMeleeDamageComponent.hpp include/components/damage/GiveMeleeDamageComponent.hpp include/components/damage/TakeTileCollisionDamageComponent.hpp include/components/damage/TakeJumpOnTopDamage.hpp include/components/damage/GiveJumpOnTopDamage.hpp)
 
 target_include_directories(GameLoop
         PRIVATE include interface

--- a/src/game-loop/CMakeLists.txt
+++ b/src/game-loop/CMakeLists.txt
@@ -91,15 +91,15 @@ add_library(GameLoop STATIC
         include/components/specialized/PauseOverlayComponent.hpp
         include/components/specialized/DeathOverlayComponent.hpp
         include/components/specialized/LevelSummaryOverlayComponent.hpp
-        include/components/damage/TakeFallDamageComponent.hpp
         include/components/damage/HitpointComponent.hpp
-        include/components/damage/TakeProjectileDamageComponent.hpp
-        include/components/damage/GiveProjectileDamageComponent.hpp
-        include/components/damage/TakeMeleeDamageComponent.hpp
         include/components/damage/GiveMeleeDamageComponent.hpp
+        include/components/damage/GiveProjectileDamageComponent.hpp
+        include/components/damage/GiveJumpOnTopDamage.hpp
+        include/components/damage/TakeFallDamageComponent.hpp
+        include/components/damage/TakeProjectileDamageComponent.hpp
+        include/components/damage/TakeMeleeDamageComponent.hpp
         include/components/damage/TakeTileCollisionDamageComponent.hpp
         include/components/damage/TakeJumpOnTopDamage.hpp
-        include/components/damage/GiveJumpOnTopDamage.hpp
 
         # Prefabs:
 

--- a/src/game-loop/CMakeLists.txt
+++ b/src/game-loop/CMakeLists.txt
@@ -247,7 +247,7 @@ add_library(GameLoop STATIC
         interface/other/Inventory.hpp
         interface/other/InventoryEvent.hpp
         include/other/LootCollectedEvent.hpp
-)
+        include/system/DamageSystem.hpp src/system/DamageSystem.cpp include/components/damage/TakeFallDamageComponent.hpp include/components/damage/HitpointComponent.hpp)
 
 target_include_directories(GameLoop
         PRIVATE include interface

--- a/src/game-loop/include/components/damage/GiveJumpOnTopDamage.hpp
+++ b/src/game-loop/include/components/damage/GiveJumpOnTopDamage.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "patterns/Subject.hpp"
+#include "components/generic/PhysicsComponent.hpp"
+
+using JumpOnTopDamage_t = int;
+class GiveJumpOnTopDamageComponent
+{
+public:
+    explicit GiveJumpOnTopDamageComponent(JumpOnTopDamage_t damage_given)
+            : _damage_given(damage_given)
+    {}
+
+    JumpOnTopDamage_t get_damage() const
+    {
+        return _damage_given;
+    }
+
+private:
+    JumpOnTopDamage_t _damage_given = 0;
+};

--- a/src/game-loop/include/components/damage/GiveMeleeDamageComponent.hpp
+++ b/src/game-loop/include/components/damage/GiveMeleeDamageComponent.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "patterns/Subject.hpp"
+#include "components/generic/PhysicsComponent.hpp"
+
+using MeleeDamage_t = int;
+class GiveMeleeDamageComponent
+{
+public:
+    explicit GiveMeleeDamageComponent(MeleeDamage_t damage_given)
+            : _damage_given(damage_given)
+    {}
+
+    MeleeDamage_t get_damage() const
+    {
+        return _damage_given;
+    }
+
+private:
+    MeleeDamage_t _damage_given = 0;
+};

--- a/src/game-loop/include/components/damage/GiveProjectileDamageComponent.hpp
+++ b/src/game-loop/include/components/damage/GiveProjectileDamageComponent.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "patterns/Subject.hpp"
+#include "components/generic/PhysicsComponent.hpp"
+
+using ProjectileDamage_t = int;
+class GiveProjectileDamageComponent
+{
+public:
+    explicit GiveProjectileDamageComponent(ProjectileDamage_t damage_given)
+        : _damage_given(damage_given)
+    {}
+
+    void set_mutual(bool mutual)
+    {
+        _mutual = mutual;
+    }
+
+    ProjectileDamage_t get_damage() const
+    {
+        return _damage_given;
+    }
+
+private:
+    ProjectileDamage_t _damage_given = 0;
+    bool _mutual = false;
+};

--- a/src/game-loop/include/components/damage/GiveProjectileDamageComponent.hpp
+++ b/src/game-loop/include/components/damage/GiveProjectileDamageComponent.hpp
@@ -3,8 +3,9 @@
 #include "patterns/Subject.hpp"
 #include "components/generic/PhysicsComponent.hpp"
 
+using MutualDamage_t = int;
 using ProjectileDamage_t = int;
-class GiveProjectileDamageComponent
+class GiveProjectileDamageComponent : public Subject<MutualDamage_t>
 {
 public:
     explicit GiveProjectileDamageComponent(ProjectileDamage_t damage_given)
@@ -14,6 +15,11 @@ public:
     void set_mutual(bool mutual)
     {
         _mutual = mutual;
+    }
+
+    bool is_mutual() const
+    {
+        return _mutual;
     }
 
     ProjectileDamage_t get_damage() const

--- a/src/game-loop/include/components/damage/HitpointComponent.hpp
+++ b/src/game-loop/include/components/damage/HitpointComponent.hpp
@@ -1,11 +1,16 @@
 #pragma once
 
 #include "patterns/Subject.hpp"
+#include "other/NpcType.hpp"
 
-struct DieEvent {};
+struct DeathEvent
+{
+    NpcType npc_type;
+};
+
 using Hitpoint_t = int;
 
-class HitpointComponent : public Subject<DieEvent>
+class HitpointComponent : public Subject<DeathEvent>
 {
 public:
     explicit HitpointComponent(Hitpoint_t hitpoints) : _hitpoints(hitpoints) {}

--- a/src/game-loop/include/components/damage/HitpointComponent.hpp
+++ b/src/game-loop/include/components/damage/HitpointComponent.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "patterns/Subject.hpp"
+
+struct DieEvent {};
+using Hitpoint_t = int;
+
+class HitpointComponent : public Subject<DieEvent>
+{
+public:
+    explicit HitpointComponent(Hitpoint_t hitpoints) : _hitpoints(hitpoints) {}
+    HitpointComponent() = default;
+
+    void remove_hitpoints(Hitpoint_t hitpoints)
+    {
+        _hitpoints -= hitpoints;
+    }
+
+    Hitpoint_t get_hitpoints() const
+    {
+        return _hitpoints;
+    }
+
+private:
+    Hitpoint_t _hitpoints = 0;
+};

--- a/src/game-loop/include/components/damage/TakeFallDamageComponent.hpp
+++ b/src/game-loop/include/components/damage/TakeFallDamageComponent.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "patterns/Subject.hpp"
+#include "components/generic/PhysicsComponent.hpp"
+
+using FallDamage_t = int;
+class TakeFallDamageComponent : public Subject<FallDamage_t>
+{
+public:
+    TakeFallDamageComponent() = default;
+    explicit TakeFallDamageComponent(FallDamage_t falling_damage) : _falling_damage(falling_damage) {}
+
+    bool update(const PhysicsComponent& physics)
+    {
+        const bool damage_taken =  _last_tick_y_velocity > _critical_speed && physics.get_y_velocity() == 0.0f;
+        _last_tick_y_velocity = physics.get_y_velocity();
+        return damage_taken;
+    }
+
+    int get_falling_damage() const
+    {
+        return _falling_damage;
+    }
+
+    void set_critical_speed(float critical_speed)
+    {
+        _critical_speed = critical_speed;
+    }
+
+private:
+    FallDamage_t _falling_damage = 0;
+    float _last_tick_y_velocity = 0.0f;
+    float _critical_speed = 0.2f;
+};

--- a/src/game-loop/include/components/damage/TakeFallDamageComponent.hpp
+++ b/src/game-loop/include/components/damage/TakeFallDamageComponent.hpp
@@ -22,11 +22,6 @@ public:
         return _falling_damage;
     }
 
-    void set_critical_speed(float critical_speed)
-    {
-        _critical_speed = critical_speed;
-    }
-
 private:
     FallDamage_t _falling_damage = 0;
     float _last_tick_y_velocity = 0.0f;

--- a/src/game-loop/include/components/damage/TakeJumpOnTopDamage.hpp
+++ b/src/game-loop/include/components/damage/TakeJumpOnTopDamage.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "patterns/Subject.hpp"
+#include "components/generic/PhysicsComponent.hpp"
+
+using JumpOnTopDamage_t = int;
+class TakeJumpOnTopDamageComponent : public Subject<JumpOnTopDamage_t>
+{
+};

--- a/src/game-loop/include/components/damage/TakeMeleeDamageComponent.hpp
+++ b/src/game-loop/include/components/damage/TakeMeleeDamageComponent.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "patterns/Subject.hpp"
+#include "components/generic/PhysicsComponent.hpp"
+
+using MeleeDamage_t = int;
+class TakeMeleeDamageComponent : public Subject<MeleeDamage_t>
+{
+};

--- a/src/game-loop/include/components/damage/TakeProjectileDamageComponent.hpp
+++ b/src/game-loop/include/components/damage/TakeProjectileDamageComponent.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "patterns/Subject.hpp"
+#include "components/generic/PhysicsComponent.hpp"
+
+using ProjectileDamage_t = int;
+class TakeProjectileDamageComponent : public Subject<ProjectileDamage_t>
+{
+};

--- a/src/game-loop/include/components/damage/TakeTileCollisionDamageComponent.hpp
+++ b/src/game-loop/include/components/damage/TakeTileCollisionDamageComponent.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "patterns/Subject.hpp"
+#include "components/generic/PhysicsComponent.hpp"
+
+#include <cmath>
+
+using TileCollisionDamage_t = int;
+class TakeTileCollisionDamageComponent : public Subject<TileCollisionDamage_t>
+{
+public:
+    TakeTileCollisionDamageComponent() = default;
+    explicit TakeTileCollisionDamageComponent(TileCollisionDamage_t tile_collision_damage,
+                                             float critical_velocity_x,
+                                             float critical_velocity_y)
+        : _tile_collision_damage(tile_collision_damage)
+        , _critical_velocity { critical_velocity_x, critical_velocity_y }
+    {}
+
+    bool update(const PhysicsComponent& physics)
+    {
+        const bool damage_taken =  (physics.get_y_velocity() == 0.0f && std::fabs(_last_tick_velocity.y) > _critical_velocity.y) ||
+                                   (physics.get_x_velocity() == 0.0f && std::fabs(_last_tick_velocity.x) > _critical_velocity.x);
+
+        _last_tick_velocity.x = physics.get_x_velocity();
+        _last_tick_velocity.y = physics.get_y_velocity();
+
+        return damage_taken;
+    }
+
+    TileCollisionDamage_t get_tile_collision_damage() const
+    {
+        return _tile_collision_damage;
+    }
+
+private:
+    TileCollisionDamage_t _tile_collision_damage = 0;
+    
+    struct
+    {
+        float x = 0.0f;
+        float y = 0.0f;
+    } _last_tick_velocity;
+    
+    struct
+    {
+        float x = 0.0f;
+        float y = 0.0f;
+    } _critical_velocity;
+};

--- a/src/game-loop/include/components/generic/NpcTypeComponent.hpp
+++ b/src/game-loop/include/components/generic/NpcTypeComponent.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "other/NpcType.hpp"
+
+struct NpcTypeComponent
+{
+    explicit NpcTypeComponent(NpcType npc_type) : npc_type(npc_type) {}
+    NpcType npc_type;
+};

--- a/src/game-loop/include/components/specialized/LevelSummaryOverlayComponent.hpp
+++ b/src/game-loop/include/components/specialized/LevelSummaryOverlayComponent.hpp
@@ -21,6 +21,9 @@ public:
 
 private:
 
+    uint32_t _kills_appearing_timer = 0;
+    uint32_t _kills_spawned = 0;
+
     uint32_t _loot_appearing_timer = 0;
     uint32_t _loot_spawned = 0;
 

--- a/src/game-loop/include/components/specialized/LevelSummaryTracker.hpp
+++ b/src/game-loop/include/components/specialized/LevelSummaryTracker.hpp
@@ -1,14 +1,17 @@
 #pragma once
 
-
+#include "components/damage/HitpointComponent.hpp"
 #include "other/InventoryEvent.hpp"
 #include "other/LootCollectedEvent.hpp"
+#include "other/NpcType.hpp"
 #include "patterns/Observer.hpp"
 
 #include <cstdint>
 #include <vector>
 
-class LevelSummaryTracker : public Observer<InventoryEvent>, public Observer<LootCollectedEvent>
+class LevelSummaryTracker : public Observer<InventoryEvent>,
+                            public Observer<LootCollectedEvent>,
+                            public Observer<DeathEvent>
 {
 public:
 
@@ -18,6 +21,7 @@ public:
     void update(uint32_t delta_time_ms);
     void on_notify(const InventoryEvent*) override;
     void on_notify(const LootCollectedEvent*) override;
+    void on_notify(const DeathEvent*) override;
 
     void entered_new_level();
     void reset();
@@ -30,7 +34,9 @@ public:
     uint32_t get_dollars_end() const { return _dollars_end; }
 
     void sort_loot_collected_events();
+    void sort_npc_killed_events();
     const std::vector<LootCollectedEvent>& get_loot_collected_events() const { return _loot_collected_events; }
+    const std::vector<NpcType>& get_npc_killed_events() const { return _npc_killed_events; }
 
 private:
     uint32_t _level_counter = 0;
@@ -41,4 +47,5 @@ private:
     uint32_t _dollars_end = 0;
 
     std::vector<LootCollectedEvent> _loot_collected_events;
+    std::vector<NpcType> _npc_killed_events;
 };

--- a/src/game-loop/include/components/specialized/LevelSummaryTracker.hpp
+++ b/src/game-loop/include/components/specialized/LevelSummaryTracker.hpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <vector>
 
+// FIXME: This is a leftover from before ECS rework. Make LevelSummarySystem + subsequent components instead.
 class LevelSummaryTracker : public Observer<InventoryEvent>,
                             public Observer<LootCollectedEvent>,
                             public Observer<DeathEvent>

--- a/src/game-loop/include/other/NpcType.hpp
+++ b/src/game-loop/include/other/NpcType.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+enum class NpcType
+{
+    NONE,
+    SNAKE,
+    BAT,
+    CAVEMAN,
+    SPIDER,
+    SKELETON
+};

--- a/src/game-loop/include/prefabs/npc/Spider.hpp
+++ b/src/game-loop/include/prefabs/npc/Spider.hpp
@@ -6,7 +6,7 @@ namespace prefabs
 {
     struct Spider
     {
-        static entt::entity create(float pos_x_center, float pos_y_center);
+        static entt::entity create(float pos_x_center, float pos_y_center, bool triggered = false);
         static entt::entity create();
     };
 }

--- a/src/game-loop/include/prefabs/particles/BloodParticle.hpp
+++ b/src/game-loop/include/prefabs/particles/BloodParticle.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "entt/entt.hpp"
+
+namespace prefabs
+{
+    struct BloodParticle
+    {
+        static entt::entity create(float pos_x_center, float pos_y_center);
+        static entt::entity create();
+    };
+}

--- a/src/game-loop/include/system/DamageSystem.hpp
+++ b/src/game-loop/include/system/DamageSystem.hpp
@@ -8,6 +8,7 @@ public:
     void update(std::uint32_t delta_time_ms) override;
 private:
     static void update_falling_damage();
+    static void update_tile_collision_damage();
     static void update_melee_damage();
     static void update_projectile_damage();
 };

--- a/src/game-loop/include/system/DamageSystem.hpp
+++ b/src/game-loop/include/system/DamageSystem.hpp
@@ -7,5 +7,6 @@ class DamageSystem final : public System
 public:
     void update(std::uint32_t delta_time_ms) override;
 private:
-    void update_falling_damage();
+    static void update_falling_damage();
+    static void update_projectile_damage();
 };

--- a/src/game-loop/include/system/DamageSystem.hpp
+++ b/src/game-loop/include/system/DamageSystem.hpp
@@ -11,4 +11,5 @@ private:
     static void update_tile_collision_damage();
     static void update_melee_damage();
     static void update_projectile_damage();
+    static void update_jump_on_top_damage();
 };

--- a/src/game-loop/include/system/DamageSystem.hpp
+++ b/src/game-loop/include/system/DamageSystem.hpp
@@ -8,5 +8,6 @@ public:
     void update(std::uint32_t delta_time_ms) override;
 private:
     static void update_falling_damage();
+    static void update_melee_damage();
     static void update_projectile_damage();
 };

--- a/src/game-loop/include/system/DamageSystem.hpp
+++ b/src/game-loop/include/system/DamageSystem.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "System.hpp"
+
+class DamageSystem final : public System
+{
+public:
+    void update(std::uint32_t delta_time_ms) override;
+private:
+    void update_falling_damage();
+};

--- a/src/game-loop/interface/game-loop/GameLoop.hpp
+++ b/src/game-loop/interface/game-loop/GameLoop.hpp
@@ -28,6 +28,7 @@ class InputSystem;
 class DisposingSystem;
 class ParticleSystem;
 class ItemSystem;
+class DamageSystem;
 
 class GameLoop
 {
@@ -64,6 +65,7 @@ private:
     std::shared_ptr<ParticleSystem> _particle_system;
     std::shared_ptr<InputSystem> _input_system;
     std::shared_ptr<ItemSystem> _item_system;
+    std::shared_ptr<DamageSystem> _damage_system;
     std::shared_ptr<Viewport> _viewport;
     std::shared_ptr<LevelSummaryTracker> _level_summary_tracker;
     std::function<bool(uint32_t delta_time_ms)> _loop;

--- a/src/game-loop/src/components/specialized/LevelSummaryOverlayComponent.cpp
+++ b/src/game-loop/src/components/specialized/LevelSummaryOverlayComponent.cpp
@@ -165,7 +165,7 @@ LevelSummaryOverlayComponent::LevelSummaryOverlayComponent(const std::shared_ptr
     }
 
     _level_summary_tracker->sort_loot_collected_events();
-    _level_summary_tracker->sort_npc_killed_events()    ;
+    _level_summary_tracker->sort_npc_killed_events();
 }
 
 void LevelSummaryOverlayComponent::update(uint32_t delta_time_ms)
@@ -180,7 +180,7 @@ void LevelSummaryOverlayComponent::update(uint32_t delta_time_ms)
     int elements_appearing = std::floor<int>(static_cast<float>(_loot_appearing_timer) / 150.0f);
     for (std::size_t index = _loot_spawned; index < elements_appearing && index < loot_events.size(); index++)
     {
-        auto &current_event = loot_events[index];
+        auto& current_event = loot_events[index];
         float x = 6.25f + (0.5 * index);
         float y = 3.25f;
 

--- a/src/game-loop/src/components/specialized/LevelSummaryTracker.cpp
+++ b/src/game-loop/src/components/specialized/LevelSummaryTracker.cpp
@@ -49,6 +49,16 @@ void LevelSummaryTracker::on_notify(const LootCollectedEvent *event)
     _loot_collected_events.push_back(*event);
 }
 
+void LevelSummaryTracker::sort_npc_killed_events()
+{
+    std::sort(_npc_killed_events.begin(), _npc_killed_events.end(),
+              [](const NpcType &e1, const NpcType &e2)
+              {
+                  return static_cast<int>(e1) < static_cast<int>(e2);
+              }
+    );
+}
+
 void LevelSummaryTracker::sort_loot_collected_events()
 {
     std::sort(_loot_collected_events.begin(), _loot_collected_events.end(),
@@ -57,4 +67,9 @@ void LevelSummaryTracker::sort_loot_collected_events()
                   return static_cast<int>(e1) < static_cast<int>(e2);
               }
     );
+}
+
+void LevelSummaryTracker::on_notify(const DeathEvent* event)
+{
+    _npc_killed_events.push_back(event->npc_type);
 }

--- a/src/game-loop/src/components/specialized/LevelSummaryTracker.cpp
+++ b/src/game-loop/src/components/specialized/LevelSummaryTracker.cpp
@@ -49,6 +49,11 @@ void LevelSummaryTracker::on_notify(const LootCollectedEvent *event)
     _loot_collected_events.push_back(*event);
 }
 
+void LevelSummaryTracker::on_notify(const DeathEvent* event)
+{
+    _npc_killed_events.push_back(event->npc_type);
+}
+
 void LevelSummaryTracker::sort_npc_killed_events()
 {
     std::sort(_npc_killed_events.begin(), _npc_killed_events.end(),
@@ -67,9 +72,4 @@ void LevelSummaryTracker::sort_loot_collected_events()
                   return static_cast<int>(e1) < static_cast<int>(e2);
               }
     );
-}
-
-void LevelSummaryTracker::on_notify(const DeathEvent* event)
-{
-    _npc_killed_events.push_back(event->npc_type);
 }

--- a/src/game-loop/src/game-loop/GameLoop.cpp
+++ b/src/game-loop/src/game-loop/GameLoop.cpp
@@ -11,6 +11,7 @@
 #include "system/ParticleSystem.hpp"
 #include "system/AnimationSystem.hpp"
 #include "system/ItemSystem.hpp"
+#include "system/DamageSystem.hpp"
 
 #include <algorithm>
 #include <cassert>
@@ -32,6 +33,7 @@ GameLoop::GameLoop(const std::shared_ptr<Viewport>& viewport)
     , _disposing_system(std::make_shared<DisposingSystem>())
     , _particle_system(std::make_shared<ParticleSystem>())
     , _item_system(std::make_shared<ItemSystem>())
+    , _damage_system(std::make_shared<DamageSystem>())
 {
     _states.current = &_states.started;
     _states.current->enter(*this);

--- a/src/game-loop/src/game-loop/GameLoopPlayingState.cpp
+++ b/src/game-loop/src/game-loop/GameLoopPlayingState.cpp
@@ -15,6 +15,7 @@
 #include "components/specialized/MainDudeComponent.hpp"
 
 #include "system/RenderingSystem.hpp"
+#include "system/DamageSystem.hpp"
 #include "system/ItemSystem.hpp"
 #include "system/CollectibleSystem.hpp"
 #include "system/ScriptingSystem.hpp"
@@ -45,6 +46,7 @@ GameLoopBaseState *GameLoopPlayingState::update(GameLoop& game_loop, uint32_t de
     auto& item_system = game_loop._item_system;
     auto& disposing_system = game_loop._disposing_system;
     auto& particle_system = game_loop._particle_system;
+    auto& damage_system = game_loop._damage_system;
 
     // Adjust camera to follow main dude:
     auto& position = registry.get<PositionComponent>(_main_dude);
@@ -85,6 +87,7 @@ GameLoopBaseState *GameLoopPlayingState::update(GameLoop& game_loop, uint32_t de
         disposing_system->update(delta_time_ms);
         collectible_system->update(delta_time_ms);
         particle_system->update(delta_time_ms);
+        damage_system->update(delta_time_ms);
     }
 
     auto& dude = registry.get<MainDudeComponent>(_main_dude);

--- a/src/game-loop/src/game-loop/GameLoopStartedState.cpp
+++ b/src/game-loop/src/game-loop/GameLoopStartedState.cpp
@@ -4,6 +4,10 @@
 #include "logger/log.h"
 #include "TextureBank.hpp"
 #include "audio/Audio.hpp"
+#include "EntityRegistry.hpp"
+
+#include "components/generic/MeshComponent.hpp"
+#include "components/generic/QuadComponent.hpp"
 
 GameLoopBaseState *GameLoopStartedState::update(GameLoop& game_loop, uint32_t delta_time_ms)
 {
@@ -27,6 +31,10 @@ void GameLoopStartedState::enter(GameLoop& game_loop)
 
     TextureBank::instance().load_textures();
     TextureBank::instance().load_texture_regions();
+
+    auto& registry = EntityRegistry::instance().get_registry();
+    registry.reserve<MeshComponent>(256);
+    registry.reserve<QuadComponent>(256);
 
     _game_initialized = true;
 }

--- a/src/game-loop/src/populator/Populator.cpp
+++ b/src/game-loop/src/populator/Populator.cpp
@@ -29,13 +29,13 @@ void populator::generate_npc(std::shared_ptr<LevelSummaryTracker>& tracker)
 
     auto& registry = EntityRegistry::instance().get_registry();
 
-    Spawner snake_spawner(7, 7);
-    Spawner bat_spawner(7, 7);
-    Spawner caveman_spawner(7, 7);
-    Spawner fake_skeleton_spawner(7, 7);
-    Spawner skeleton_spawner(7, 7);
+    Spawner snake_spawner(3, 4);
+    Spawner bat_spawner(3, 4);
+    Spawner caveman_spawner(3, 4);
+    Spawner fake_skeleton_spawner(3, 4);
+    Spawner skeleton_spawner(3, 4);
     Spawner spikes_spawner(3, 4);
-    Spawner spider_spawner(7, 7);
+    Spawner spider_spawner(3, 3);
 
     std::vector<std::shared_ptr<GameEntity>> out{};
 

--- a/src/game-loop/src/populator/Populator.cpp
+++ b/src/game-loop/src/populator/Populator.cpp
@@ -27,14 +27,6 @@ void populator::generate_npc(std::shared_ptr<LevelSummaryTracker>& tracker)
 {
     auto& registry = EntityRegistry::instance().get_registry();
 
-//    Spawner snake_spawner(10, 20);
-//    Spawner bat_spawner(3, 0);
-//    Spawner caveman_spawner(3, 0);
-//    Spawner fake_skeleton_spawner(3, 0);
-//    Spawner skeleton_spawner(3, 0);
-//    Spawner spikes_spawner(3, 0);
-//    Spawner spider_spawner(3, 0);
-
     Spawner snake_spawner(3, 4);
     Spawner bat_spawner(3, 4);
     Spawner caveman_spawner(3, 4);

--- a/src/game-loop/src/populator/Populator.cpp
+++ b/src/game-loop/src/populator/Populator.cpp
@@ -25,9 +25,15 @@
 
 void populator::generate_npc(std::shared_ptr<LevelSummaryTracker>& tracker)
 {
-    // TODO: Make use of LevelSummaryTracker to keep count of killed NPC's.
-
     auto& registry = EntityRegistry::instance().get_registry();
+
+//    Spawner snake_spawner(10, 20);
+//    Spawner bat_spawner(3, 0);
+//    Spawner caveman_spawner(3, 0);
+//    Spawner fake_skeleton_spawner(3, 0);
+//    Spawner skeleton_spawner(3, 0);
+//    Spawner spikes_spawner(3, 0);
+//    Spawner spider_spawner(3, 0);
 
     Spawner snake_spawner(3, 4);
     Spawner bat_spawner(3, 4);
@@ -58,6 +64,7 @@ void populator::generate_npc(std::shared_ptr<LevelSummaryTracker>& tracker)
                     {
                         spider_spawner.spawned();
                         prefabs::Spider::create(pos_x, pos_y);
+
                     }
                     break;
                 }
@@ -76,27 +83,35 @@ void populator::generate_npc(std::shared_ptr<LevelSummaryTracker>& tracker)
                     if (snake_spawner.can_spawn())
                     {
                         snake_spawner.spawned();
-                        prefabs::Snake::create(pos_x, pos_y);
+                        auto entity = prefabs::Snake::create(pos_x, pos_y);
+                        auto& hitpoints = registry.get<HitpointComponent>(entity);
+                        hitpoints.add_observer(tracker.get());
                     }
                     else if (bat_spawner.can_spawn())
                     {
                         bat_spawner.spawned();
-                        prefabs::Bat::create(pos_x, pos_y);
+                        auto entity = prefabs::Bat::create(pos_x, pos_y);
+                        auto& hitpoints = registry.get<HitpointComponent>(entity);
+                        hitpoints.add_observer(tracker.get());
                     }
                     else if (caveman_spawner.can_spawn())
                     {
                         caveman_spawner.spawned();
-                        prefabs::Caveman::create(pos_x, pos_y);
+                        auto entity = prefabs::Caveman::create(pos_x, pos_y);
+                        auto& hitpoints = registry.get<HitpointComponent>(entity);
+                        hitpoints.add_observer(tracker.get());
                     }
                     else if (fake_skeleton_spawner.can_spawn())
                     {
                         fake_skeleton_spawner.spawned();
-                        prefabs::FakeSkeleton ::create(pos_x, pos_y);
+                        prefabs::FakeSkeleton::create(pos_x, pos_y);
                     }
                     else if (skeleton_spawner.can_spawn())
                     {
                         skeleton_spawner.spawned();
-                        prefabs::Skeleton::create(pos_x, pos_y);
+                        auto entity = prefabs::Skeleton::create(pos_x, pos_y);
+                        auto& hitpoints = registry.get<HitpointComponent>(entity);
+                        hitpoints.add_observer(tracker.get());
                     }
                     else if (spikes_spawner.can_spawn())
                     {

--- a/src/game-loop/src/populator/Populator.cpp
+++ b/src/game-loop/src/populator/Populator.cpp
@@ -29,13 +29,13 @@ void populator::generate_npc(std::shared_ptr<LevelSummaryTracker>& tracker)
 
     auto& registry = EntityRegistry::instance().get_registry();
 
-    Spawner snake_spawner(3, 4);
-    Spawner bat_spawner(3, 4);
-    Spawner caveman_spawner(3, 4);
-    Spawner fake_skeleton_spawner(3, 4);
-    Spawner skeleton_spawner(3, 4);
+    Spawner snake_spawner(7, 7);
+    Spawner bat_spawner(7, 7);
+    Spawner caveman_spawner(7, 7);
+    Spawner fake_skeleton_spawner(7, 7);
+    Spawner skeleton_spawner(7, 7);
     Spawner spikes_spawner(3, 4);
-    Spawner spider_spawner(3, 4);
+    Spawner spider_spawner(7, 7);
 
     std::vector<std::shared_ptr<GameEntity>> out{};
 

--- a/src/game-loop/src/prefabs/items/Arrow.cpp
+++ b/src/game-loop/src/prefabs/items/Arrow.cpp
@@ -7,6 +7,7 @@
 #include "components/generic/HorizontalOrientationComponent.hpp"
 #include "components/generic/MeshComponent.hpp"
 #include "components/generic/ScriptingComponent.hpp"
+#include "components/generic/ItemCarrierComponent.hpp"
 #include "components/damage/GiveProjectileDamageComponent.hpp"
 
 #include "EntityRegistry.hpp"
@@ -17,9 +18,43 @@
 
 namespace
 {
+    class ArrowMutualDamageObserver final : public Observer<MutualDamage_t>
+    {
+    public:
+
+        explicit ArrowMutualDamageObserver(entt::entity arrow) : _arrow(arrow) {}
+
+        void on_notify(const MutualDamage_t *) override
+        {
+            auto& registry = EntityRegistry::instance().get_registry();
+
+            auto& projectile_damage_component = registry.get<GiveProjectileDamageComponent>(_arrow);
+            projectile_damage_component.remove_observer(this);
+
+            auto& item = registry.get<ItemComponent>(_arrow);
+            if (item.is_carried())
+            {
+                auto& item_carrier = item.get_item_carrier();
+                item_carrier.put_down_active_item();
+            }
+
+            registry.destroy(_arrow);
+        }
+
+    private:
+        const entt::entity _arrow;
+    };
+
     class ArrowScript final : public ScriptBase
     {
     public:
+
+        explicit ArrowScript(entt::entity arrow) : _damage_observer(arrow) {}
+
+        ArrowMutualDamageObserver* get_observer()
+        {
+            return &_damage_observer;
+        }
 
         void update(entt::entity owner, uint32_t delta_time_ms) override
         {
@@ -39,6 +74,7 @@ namespace
             }
         }
     private:
+        ArrowMutualDamageObserver _damage_observer;
         NPCSpritesheetFrames _current = NPCSpritesheetFrames::ARROW;
 
         void set_frame(NPCSpritesheetFrames frame, entt::entity owner)
@@ -81,14 +117,21 @@ entt::entity prefabs::Arrow::create(float pos_x_center, float pos_y_center)
     ItemComponent item(ItemType::THROWABLE, ItemSlot::ACTIVE);
     item.set_weight(1.0f);
 
+    auto arrow_script = std::make_shared<ArrowScript>(entity);
+    ScriptingComponent script(arrow_script);
+
+    GiveProjectileDamageComponent give_projectile_damage(2);
+    give_projectile_damage.set_mutual(true);
+    give_projectile_damage.add_observer(reinterpret_cast<Observer<MutualDamage_t>*>(arrow_script->get_observer()));
+
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<QuadComponent>(entity, quad);
     registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_2_ITEMS, CameraType::MODEL_VIEW_SPACE);
     registry.emplace<PhysicsComponent>(entity, physics);
     registry.emplace<ItemComponent>(entity, item);
-    registry.emplace<ScriptingComponent>(entity, std::make_shared<ArrowScript>());
+    registry.emplace<ScriptingComponent>(entity, script);
     registry.emplace<HorizontalOrientationComponent>(entity);
-    registry.emplace<GiveProjectileDamageComponent>(entity, 2);
+    registry.emplace<GiveProjectileDamageComponent>(entity, give_projectile_damage);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/items/Arrow.cpp
+++ b/src/game-loop/src/prefabs/items/Arrow.cpp
@@ -7,6 +7,7 @@
 #include "components/generic/HorizontalOrientationComponent.hpp"
 #include "components/generic/MeshComponent.hpp"
 #include "components/generic/ScriptingComponent.hpp"
+#include "components/damage/GiveProjectileDamageComponent.hpp"
 
 #include "EntityRegistry.hpp"
 #include "TextureType.hpp"
@@ -87,6 +88,7 @@ entt::entity prefabs::Arrow::create(float pos_x_center, float pos_y_center)
     registry.emplace<ItemComponent>(entity, item);
     registry.emplace<ScriptingComponent>(entity, std::make_shared<ArrowScript>());
     registry.emplace<HorizontalOrientationComponent>(entity);
+    registry.emplace<GiveProjectileDamageComponent>(entity, 2);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/items/Bomb.cpp
+++ b/src/game-loop/src/prefabs/items/Bomb.cpp
@@ -12,6 +12,7 @@
 #include "components/generic/ItemComponent.hpp"
 #include "components/specialized/MainDudeComponent.hpp"
 #include "components/generic/ScriptingComponent.hpp"
+#include "components/damage/GiveProjectileDamageComponent.hpp"
 
 #include "EntityRegistry.hpp"
 #include "Level.hpp"
@@ -162,6 +163,7 @@ entt::entity prefabs::Bomb::create(float pos_x_center, float pos_y_center)
     registry.emplace<ScriptingComponent>(entity, std::make_shared<BombScript>());
     registry.emplace<HorizontalOrientationComponent>(entity);
     registry.emplace<ActivableComponent>(entity, activable);
+    registry.emplace<GiveProjectileDamageComponent>(entity, 1);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/items/Chest.cpp
+++ b/src/game-loop/src/prefabs/items/Chest.cpp
@@ -9,6 +9,7 @@
 #include "components/generic/ItemComponent.hpp"
 #include "components/generic/OpenableComponent.hpp"
 #include "components/generic/ScriptingComponent.hpp"
+#include "components/damage/GiveProjectileDamageComponent.hpp"
 
 #include "EntityRegistry.hpp"
 #include "TextureType.hpp"
@@ -94,6 +95,7 @@ entt::entity prefabs::Chest::create(float pos_x_center, float pos_y_center)
     registry.emplace<ScriptingComponent>(entity, std::make_shared<ChestScript>());
     registry.emplace<HorizontalOrientationComponent>(entity);
     registry.emplace<OpenableComponent>(entity);
+    registry.emplace<GiveProjectileDamageComponent>(entity, 1);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/items/Crate.cpp
+++ b/src/game-loop/src/prefabs/items/Crate.cpp
@@ -8,6 +8,7 @@
 #include "prefabs/particles/RopeCollectedParticle.hpp"
 #include "prefabs/particles/BombCollectedParticle.hpp"
 
+#include "components/damage/GiveProjectileDamageComponent.hpp"
 #include "components/generic/PhysicsComponent.hpp"
 #include "components/generic/ItemCarrierComponent.hpp"
 #include "components/generic/HorizontalOrientationComponent.hpp"
@@ -145,6 +146,7 @@ entt::entity prefabs::Crate::create(float pos_x_center, float pos_y_center)
     registry.emplace<ScriptingComponent>(entity, std::make_shared<CrateScript>());
     registry.emplace<HorizontalOrientationComponent>(entity);
     registry.emplace<OpenableComponent>(entity);
+    registry.emplace<GiveProjectileDamageComponent>(entity, 1);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/items/Jar.cpp
+++ b/src/game-loop/src/prefabs/items/Jar.cpp
@@ -5,6 +5,7 @@
 #include "prefabs/collectibles/GoldChunk.hpp"
 #include "prefabs/collectibles/GoldNugget.hpp"
 
+#include "components/damage/GiveProjectileDamageComponent.hpp"
 #include "components/generic/ItemComponent.hpp"
 #include "components/generic/PhysicsComponent.hpp"
 #include "components/generic/PositionComponent.hpp"
@@ -119,6 +120,7 @@ entt::entity prefabs::Jar::create(float pos_x_center, float pos_y_center)
     registry.emplace<ItemComponent>(entity, item);
     registry.emplace<ScriptingComponent>(entity, std::make_shared<JarScript>());
     registry.emplace<HorizontalOrientationComponent>(entity);
+    registry.emplace<GiveProjectileDamageComponent>(entity, 1);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/items/Jar.cpp
+++ b/src/game-loop/src/prefabs/items/Jar.cpp
@@ -44,13 +44,13 @@ namespace
         return static_cast<JarLootType>(std::rand() % static_cast<int>(JarLootType::_SIZE));
     }
 
-    class JarDeathObserver final : public Observer<DieEvent>
+    class JarDeathObserver final : public Observer<DeathEvent>
     {
     public:
 
         explicit JarDeathObserver(entt::entity jar) : _jar(jar) {}
 
-        void on_notify(const DieEvent*) override
+        void on_notify(const DeathEvent*) override
         {
             auto& registry = EntityRegistry::instance().get_registry();
 
@@ -91,8 +91,6 @@ namespace
                 auto& item_carrier = item.get_item_carrier();
                 item_carrier.put_down_active_item();
             }
-
-            registry.destroy(_jar);
         }
 
     private:
@@ -150,7 +148,7 @@ entt::entity prefabs::Jar::create(float pos_x_center, float pos_y_center)
     give_projectile_damage.set_mutual(true);
 
     HitpointComponent hitpoints(1);
-    hitpoints.add_observer(reinterpret_cast<Observer<DieEvent>*>(jar_script->get_observer()));
+    hitpoints.add_observer(reinterpret_cast<Observer<DeathEvent>*>(jar_script->get_observer()));
 
     float critical_speed_x = 0.1f;
     float critical_speed_y = 0.1f;

--- a/src/game-loop/src/prefabs/items/Jar.cpp
+++ b/src/game-loop/src/prefabs/items/Jar.cpp
@@ -4,9 +4,16 @@
 #include "prefabs/collectibles/BigGem.hpp"
 #include "prefabs/collectibles/GoldChunk.hpp"
 #include "prefabs/collectibles/GoldNugget.hpp"
+#include "prefabs/npc/Spider.hpp"
+#include "prefabs/npc/Snake.hpp"
 
 #include "components/damage/GiveProjectileDamageComponent.hpp"
+#include "components/damage/HitpointComponent.hpp"
+#include "components/damage/TakeTileCollisionDamageComponent.hpp"
+#include "components/damage/TakeProjectileDamageComponent.hpp"
+#include "components/damage/TakeMeleeDamageComponent.hpp"
 #include "components/generic/ItemComponent.hpp"
+#include "components/generic/ItemCarrierComponent.hpp"
 #include "components/generic/PhysicsComponent.hpp"
 #include "components/generic/PositionComponent.hpp"
 #include "components/generic/QuadComponent.hpp"
@@ -27,6 +34,8 @@ namespace
         BIG_GEM,
         GOLD_CHUNK,
         GOLD_NUGGET,
+        SPIDER,
+        SNAKE,
         _SIZE
     };
 
@@ -35,57 +44,78 @@ namespace
         return static_cast<JarLootType>(std::rand() % static_cast<int>(JarLootType::_SIZE));
     }
 
+    class JarDeathObserver final : public Observer<DieEvent>
+    {
+    public:
+
+        explicit JarDeathObserver(entt::entity jar) : _jar(jar) {}
+
+        void on_notify(const DieEvent*) override
+        {
+            auto& registry = EntityRegistry::instance().get_registry();
+
+            auto& position = registry.get<PositionComponent>(_jar);
+            prefabs::SmokePuffParticle::create(position.x_center, position.y_center);
+
+            switch (get_random_loot())
+            {
+                case JarLootType::BIG_GEM: prefabs::BigGem::create(position.x_center, position.y_center); break;
+                case JarLootType::GOLD_CHUNK: prefabs::GoldChunk::create(position.x_center, position.y_center); break;
+                case JarLootType::GOLD_NUGGET: prefabs::GoldNugget::create(position.x_center, position.y_center); break;
+                case JarLootType::SPIDER: prefabs::Spider::create(position.x_center, position.y_center, true); break;
+                case JarLootType::SNAKE: prefabs::Snake::create(position.x_center, position.y_center); break;
+                default: assert(false);
+            }
+
+            for (int index = 0; index < 5; ++index)
+            {
+                auto rubble = prefabs::RubbleSmallParticle::create(position.x_center, position.y_center);
+                auto& rubble_physics = registry.get<PhysicsComponent>(rubble);
+
+                float rubble_velocity_x = 0;
+                float rubble_velocity_y = 0;
+
+                rubble_velocity_x = static_cast<float>(std::rand() % 10) / 100.0f;
+                rubble_velocity_y = static_cast<float>(std::rand() % 10) / 100.0f;
+
+                rubble_physics.set_x_velocity(rubble_velocity_x);
+                rubble_physics.set_y_velocity(rubble_velocity_y);
+            }
+
+            auto& hitpoints = registry.get<HitpointComponent>(_jar);
+            hitpoints.remove_observer(this);
+
+            auto& item = registry.get<ItemComponent>(_jar);
+            if (item.is_carried())
+            {
+                auto& item_carrier = item.get_item_carrier();
+                item_carrier.put_down_active_item();
+            }
+
+            registry.destroy(_jar);
+        }
+
+    private:
+        const entt::entity _jar;
+    };
+
     class JarScript final : public ScriptBase
     {
     public:
 
+        explicit JarScript(entt::entity jar) : _death_observer(jar) {}
+
+        JarDeathObserver* get_observer()
+        {
+            return &_death_observer;
+        }
+
         void update(entt::entity owner, uint32_t delta_time_ms) override
         {
-            auto& registry = EntityRegistry::instance().get_registry();
-            auto& physics = registry.get<PhysicsComponent>(owner);
-
-            if (physics.is_left_collision() || physics.is_right_collision() ||
-                physics.is_upper_collision() || physics.is_bottom_collision())
-            {
-                if (std::fabs(_last_x_speed) > 0.15f || std::fabs(_last_y_speed) > 0.13f)
-                {
-                    auto& position = registry.get<PositionComponent>(owner);
-                    prefabs::SmokePuffParticle::create(position.x_center, position.y_center);
-
-                    switch (get_random_loot())
-                    {
-                        case JarLootType::BIG_GEM: prefabs::BigGem::create(position.x_center, position.y_center); break;
-                        case JarLootType::GOLD_CHUNK: prefabs::GoldChunk::create(position.x_center, position.y_center); break;
-                        case JarLootType::GOLD_NUGGET: prefabs::GoldNugget::create(position.x_center, position.y_center); break;
-                    }
-
-                    for (int index = 0; index < 5; ++index)
-                    {
-                        auto rubble = prefabs::RubbleSmallParticle::create(position.x_center, position.y_center);
-                        auto& rubble_physics = registry.get<PhysicsComponent>(rubble);
-
-                        float rubble_velocity_x = 0;
-                        float rubble_velocity_y = 0;
-
-                        rubble_velocity_x = static_cast<float>(std::rand() % 10) / 100.0f;
-                        rubble_velocity_y = static_cast<float>(std::rand() % 10) / 100.0f;
-
-                        rubble_physics.set_x_velocity(rubble_velocity_x);
-                        rubble_physics.set_y_velocity(rubble_velocity_y);
-
-                    }
-
-                    registry.destroy(owner);
-                }
-            }
-
-            _last_x_speed = physics.get_x_velocity();
-            _last_y_speed = physics.get_y_velocity();
         }
 
     private:
-        float _last_x_speed = 0;
-        float _last_y_speed = 0;
+        JarDeathObserver _death_observer;
     };
 }
 
@@ -113,14 +143,31 @@ entt::entity prefabs::Jar::create(float pos_x_center, float pos_y_center)
     item.set_weight(2);
     item.set_carrying_offset({0.0f, -1.0f/8.0f});
 
+    auto jar_script = std::make_shared<JarScript>(entity);
+    ScriptingComponent script(jar_script);
+
+    GiveProjectileDamageComponent give_projectile_damage(2);
+    give_projectile_damage.set_mutual(true);
+
+    HitpointComponent hitpoints(1);
+    hitpoints.add_observer(reinterpret_cast<Observer<DieEvent>*>(jar_script->get_observer()));
+
+    float critical_speed_x = 0.1f;
+    float critical_speed_y = 0.1f;
+    TakeTileCollisionDamageComponent tile_collision_damage(1, critical_speed_x, critical_speed_y);
+
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<QuadComponent>(entity, quad);
     registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_2_ITEMS, CameraType::MODEL_VIEW_SPACE);
     registry.emplace<PhysicsComponent>(entity, physics);
     registry.emplace<ItemComponent>(entity, item);
-    registry.emplace<ScriptingComponent>(entity, std::make_shared<JarScript>());
+    registry.emplace<ScriptingComponent>(entity, jar_script);
     registry.emplace<HorizontalOrientationComponent>(entity);
-    registry.emplace<GiveProjectileDamageComponent>(entity, 1);
+    registry.emplace<TakeMeleeDamageComponent>(entity);
+    registry.emplace<TakeProjectileDamageComponent>(entity);
+    registry.emplace<GiveProjectileDamageComponent>(entity, give_projectile_damage);
+    registry.emplace<TakeTileCollisionDamageComponent>(entity, tile_collision_damage);
+    registry.emplace<HitpointComponent>(entity, hitpoints);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/items/Rock.cpp
+++ b/src/game-loop/src/prefabs/items/Rock.cpp
@@ -1,5 +1,6 @@
 #include "prefabs/items/Rock.hpp"
 
+#include "components/damage/GiveProjectileDamageComponent.hpp"
 #include "components/generic/PhysicsComponent.hpp"
 #include "components/generic/HorizontalOrientationComponent.hpp"
 #include "components/generic/PositionComponent.hpp"
@@ -41,6 +42,7 @@ entt::entity prefabs::Rock::create(float pos_x_center, float pos_y_center)
     registry.emplace<PhysicsComponent>(entity, physics);
     registry.emplace<ItemComponent>(entity, item);
     registry.emplace<HorizontalOrientationComponent>(entity);
+    registry.emplace<GiveProjectileDamageComponent>(entity, 1);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/items/Rope.cpp
+++ b/src/game-loop/src/prefabs/items/Rope.cpp
@@ -1,6 +1,7 @@
 #include "prefabs/items/Rope.hpp"
 #include "prefabs/items/RopeChainElement.hpp"
 
+#include "components/damage/GiveProjectileDamageComponent.hpp"
 #include "components/generic/HorizontalOrientationComponent.hpp"
 #include "components/generic/ActivableComponent.hpp"
 #include "components/generic/PhysicsComponent.hpp"
@@ -135,6 +136,7 @@ entt::entity prefabs::Rope::create(float pos_x_center, float pos_y_center)
     registry.emplace<ScriptingComponent>(entity, std::make_shared<RopeScript>());
     registry.emplace<HorizontalOrientationComponent>(entity);
     registry.emplace<ActivableComponent>(entity, activable);
+    registry.emplace<GiveProjectileDamageComponent>(entity, 1);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/items/Skull.cpp
+++ b/src/game-loop/src/prefabs/items/Skull.cpp
@@ -2,6 +2,7 @@
 #include "prefabs/particles/SmokePuffParticle.hpp"
 #include "prefabs/particles/BonesParticle.hpp"
 
+#include "components/damage/GiveProjectileDamageComponent.hpp"
 #include "components/generic/ItemComponent.hpp"
 #include "components/generic/PhysicsComponent.hpp"
 #include "components/generic/PositionComponent.hpp"
@@ -86,6 +87,7 @@ entt::entity prefabs::Skull::create(float pos_x_center, float pos_y_center)
     registry.emplace<PhysicsComponent>(entity, physics);
     registry.emplace<ItemComponent>(entity, item);
     registry.emplace<HorizontalOrientationComponent>(entity);
+    registry.emplace<GiveProjectileDamageComponent>(entity, 1);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/items/Skull.cpp
+++ b/src/game-loop/src/prefabs/items/Skull.cpp
@@ -22,13 +22,13 @@
 
 namespace
 {
-    class SkullDeathObserver final : public Observer<DieEvent>
+    class SkullDeathObserver final : public Observer<DeathEvent>
     {
     public:
 
         explicit SkullDeathObserver(entt::entity skull) : _skull(skull) {}
 
-        void on_notify(const DieEvent*) override
+        void on_notify(const DeathEvent*) override
         {
             auto& registry = EntityRegistry::instance().get_registry();
             const auto& position = registry.get<PositionComponent>(_skull);
@@ -49,8 +49,6 @@ namespace
                 auto& item_carrier = item.get_item_carrier();
                 item_carrier.put_down_active_item();
             }
-
-            registry.destroy(_skull);
         }
 
     private:
@@ -104,9 +102,9 @@ entt::entity prefabs::Skull::create(float pos_x_center, float pos_y_center)
     ScriptingComponent script(skull_script);
 
     HitpointComponent hitpoints(1);
-    hitpoints.add_observer(reinterpret_cast<Observer<DieEvent>*>(skull_script->get_observer()));
+    hitpoints.add_observer(reinterpret_cast<Observer<DeathEvent>*>(skull_script->get_observer()));
 
-    GiveProjectileDamageComponent give_projectile_damage(2);
+    GiveProjectileDamageComponent give_projectile_damage(1);
     give_projectile_damage.set_mutual(true);
 
     float critical_speed_x = 0.1f;

--- a/src/game-loop/src/prefabs/items/Whip.cpp
+++ b/src/game-loop/src/prefabs/items/Whip.cpp
@@ -10,6 +10,7 @@
 #include "components/generic/MeshComponent.hpp"
 #include "components/generic/ScriptingComponent.hpp"
 #include "components/specialized/MainDudeComponent.hpp"
+#include "components/damage/GiveMeleeDamageComponent.hpp"
 
 #include "EntityRegistry.hpp"
 #include "TextureType.hpp"
@@ -98,6 +99,10 @@ namespace
             {
                 registry.remove<MeshComponent>(owner);
             }
+            if (registry.has<GiveMeleeDamageComponent>(owner))
+            {
+                registry.remove<GiveMeleeDamageComponent>(owner);
+            }
         }
         
         void show(entt::entity owner)
@@ -115,6 +120,7 @@ namespace
 
             registry.emplace<MeshComponent>(owner, mesh);
             registry.emplace<QuadComponent>(owner, quad);
+            registry.emplace<GiveMeleeDamageComponent>(owner, 1);
         }
     };
 }

--- a/src/game-loop/src/prefabs/main-dude/MainDude.cpp
+++ b/src/game-loop/src/prefabs/main-dude/MainDude.cpp
@@ -3,6 +3,7 @@
 #include "prefabs/items/RopeSpawner.hpp"
 #include "prefabs/items/Whip.hpp"
 
+#include "components/damage/GiveJumpOnTopDamage.hpp"
 #include "components/generic/PositionComponent.hpp"
 #include "components/generic/QuadComponent.hpp"
 #include "components/generic/AnimationComponent.hpp"
@@ -47,6 +48,7 @@ namespace prefabs
         registry.emplace<InputComponent>(entity, input);
         registry.emplace<HorizontalOrientationComponent>(entity);
         registry.emplace<ItemCarrierComponent>(entity, item_carrier);
+        registry.emplace<GiveJumpOnTopDamageComponent>(entity, 1);
 
         // Initialization order is important in this case - MainDudeComponent must be the last to create.
         MainDudeComponent main_dude(entity);

--- a/src/game-loop/src/prefabs/npc/Bat.cpp
+++ b/src/game-loop/src/prefabs/npc/Bat.cpp
@@ -9,6 +9,7 @@
 #include "components/generic/HorizontalOrientationComponent.hpp"
 #include "components/generic/MeshComponent.hpp"
 #include "components/generic/ScriptingComponent.hpp"
+#include "components/damage/TakeJumpOnTopDamage.hpp"
 #include "components/damage/HitpointComponent.hpp"
 #include "components/damage/TakeProjectileDamageComponent.hpp"
 #include "components/damage/TakeMeleeDamageComponent.hpp"
@@ -231,6 +232,7 @@ entt::entity prefabs::Bat::create(float pos_x_center, float pos_y_center)
     registry.emplace<HitpointComponent>(entity, hitpoints);
     registry.emplace<TakeProjectileDamageComponent>(entity);
     registry.emplace<TakeMeleeDamageComponent>(entity);
+    registry.emplace<TakeJumpOnTopDamageComponent>(entity);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/npc/Bat.cpp
+++ b/src/game-loop/src/prefabs/npc/Bat.cpp
@@ -1,4 +1,5 @@
 #include "prefabs/npc/Bat.hpp"
+#include "prefabs/particles/BloodParticle.hpp"
 
 #include "components/specialized/MainDudeComponent.hpp"
 #include "components/generic/AnimationComponent.hpp"
@@ -8,6 +9,8 @@
 #include "components/generic/HorizontalOrientationComponent.hpp"
 #include "components/generic/MeshComponent.hpp"
 #include "components/generic/ScriptingComponent.hpp"
+#include "components/damage/HitpointComponent.hpp"
+#include "components/damage/TakeProjectileDamageComponent.hpp"
 
 #include "EntityRegistry.hpp"
 #include "TextureType.hpp"
@@ -23,9 +26,54 @@ namespace
     constexpr float x_speed = 0.02f;
     constexpr float y_speed = 0.02f;
 
+    class BatDeathObserver final : public Observer<DieEvent>
+    {
+    public:
+
+        explicit BatDeathObserver(entt::entity Bat) : _bat(Bat) {}
+
+        void on_notify(const DieEvent*) override
+        {
+            auto& registry = EntityRegistry::instance().get_registry();
+            auto& position = registry.get<PositionComponent>(_bat);
+
+            {
+                auto blood = prefabs::BloodParticle::create(position.x_center, position.y_center);
+                auto& physics = registry.get<PhysicsComponent>(blood);
+                physics.set_x_velocity(-0.1f);
+                physics.set_y_velocity(-0.1f);
+            }
+
+            {
+                auto blood = prefabs::BloodParticle::create(position.x_center, position.y_center);
+                auto& physics = registry.get<PhysicsComponent>(blood);
+                physics.set_x_velocity(0.0f);
+                physics.set_y_velocity(-0.1f);
+            }
+
+            {
+                auto blood = prefabs::BloodParticle::create(position.x_center, position.y_center);
+                auto& physics = registry.get<PhysicsComponent>(blood);
+                physics.set_x_velocity(0.1f);
+                physics.set_y_velocity(-0.1f);
+            }
+
+            registry.destroy(_bat);
+        }
+
+    private:
+        const entt::entity _bat;
+    };
+    
     class BatScript final : public ScriptBase
     {
     public:
+        explicit BatScript(entt::entity bat) : _death_observer(bat) {}
+
+        BatDeathObserver* get_observer()
+        {
+            return &_death_observer;
+        }
 
         void update(entt::entity owner, uint32_t delta_time_ms) override
         {
@@ -136,6 +184,7 @@ namespace
             }
         }
     private:
+        BatDeathObserver _death_observer;
         bool _flying = false;
         bool _flying_animation_started = false;
         bool _triggered = false;
@@ -166,13 +215,21 @@ entt::entity prefabs::Bat::create(float pos_x_center, float pos_y_center)
     PhysicsComponent physics(width  - (2.0f / 16.0f), height - (2.0f / 16.0f));
     physics.disable_gravity();
 
+    auto bat_script = std::make_shared<BatScript>(entity);
+    ScriptingComponent script(bat_script);
+
+    HitpointComponent hitpoints(1);
+    hitpoints.add_observer(reinterpret_cast<Observer<DieEvent>*>(bat_script->get_observer()));
+
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<QuadComponent>(entity, quad);
     registry.emplace<AnimationComponent>(entity);
     registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_2_ITEMS, CameraType::MODEL_VIEW_SPACE);
     registry.emplace<PhysicsComponent>(entity, physics);
-    registry.emplace<ScriptingComponent>(entity, std::make_shared<BatScript>());
+    registry.emplace<ScriptingComponent>(entity, script);
     registry.emplace<HorizontalOrientationComponent>(entity);
+    registry.emplace<HitpointComponent>(entity, hitpoints);
+    registry.emplace<TakeProjectileDamageComponent>(entity);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/npc/Bat.cpp
+++ b/src/game-loop/src/prefabs/npc/Bat.cpp
@@ -38,25 +38,24 @@ namespace
             auto& registry = EntityRegistry::instance().get_registry();
             auto& position = registry.get<PositionComponent>(_bat);
 
+            for (std::size_t index = 0; index < 4; index++)
             {
-                auto blood = prefabs::BloodParticle::create(position.x_center, position.y_center);
-                auto& physics = registry.get<PhysicsComponent>(blood);
-                physics.set_x_velocity(-0.1f);
-                physics.set_y_velocity(-0.1f);
-            }
+                auto particle = prefabs::BloodParticle::create(position.x_center, position.y_center);
+                auto& physics = registry.get<PhysicsComponent>(particle);
 
-            {
-                auto blood = prefabs::BloodParticle::create(position.x_center, position.y_center);
-                auto& physics = registry.get<PhysicsComponent>(blood);
-                physics.set_x_velocity(0.0f);
-                physics.set_y_velocity(-0.1f);
-            }
+                float v_x = static_cast<float>(std::rand() % 2) / 15.0f;
+                float v_y = static_cast<float>(std::rand() % 2) / 10.0f;
 
-            {
-                auto blood = prefabs::BloodParticle::create(position.x_center, position.y_center);
-                auto& physics = registry.get<PhysicsComponent>(blood);
-                physics.set_x_velocity(0.1f);
-                physics.set_y_velocity(-0.1f);
+                if (std::rand() % 2)
+                {
+                    v_x += 0.1f;
+                }
+                else
+                {
+                    v_x -= 0.1f;
+                }
+
+                physics.set_velocity(v_x, v_y);
             }
 
             registry.destroy(_bat);

--- a/src/game-loop/src/prefabs/npc/Bat.cpp
+++ b/src/game-loop/src/prefabs/npc/Bat.cpp
@@ -11,6 +11,7 @@
 #include "components/generic/ScriptingComponent.hpp"
 #include "components/damage/HitpointComponent.hpp"
 #include "components/damage/TakeProjectileDamageComponent.hpp"
+#include "components/damage/TakeMeleeDamageComponent.hpp"
 
 #include "EntityRegistry.hpp"
 #include "TextureType.hpp"
@@ -230,6 +231,7 @@ entt::entity prefabs::Bat::create(float pos_x_center, float pos_y_center)
     registry.emplace<HorizontalOrientationComponent>(entity);
     registry.emplace<HitpointComponent>(entity, hitpoints);
     registry.emplace<TakeProjectileDamageComponent>(entity);
+    registry.emplace<TakeMeleeDamageComponent>(entity);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/npc/Bat.cpp
+++ b/src/game-loop/src/prefabs/npc/Bat.cpp
@@ -3,6 +3,7 @@
 
 #include "components/specialized/MainDudeComponent.hpp"
 #include "components/generic/AnimationComponent.hpp"
+#include "components/generic/NpcTypeComponent.hpp"
 #include "components/generic/PhysicsComponent.hpp"
 #include "components/generic/PositionComponent.hpp"
 #include "components/generic/QuadComponent.hpp"
@@ -28,13 +29,13 @@ namespace
     constexpr float x_speed = 0.02f;
     constexpr float y_speed = 0.02f;
 
-    class BatDeathObserver final : public Observer<DieEvent>
+    class BatDeathObserver final : public Observer<DeathEvent>
     {
     public:
 
         explicit BatDeathObserver(entt::entity Bat) : _bat(Bat) {}
 
-        void on_notify(const DieEvent*) override
+        void on_notify(const DeathEvent*) override
         {
             auto& registry = EntityRegistry::instance().get_registry();
             auto& position = registry.get<PositionComponent>(_bat);
@@ -58,8 +59,6 @@ namespace
 
                 physics.set_velocity(v_x, v_y);
             }
-
-            registry.destroy(_bat);
         }
 
     private:
@@ -220,7 +219,7 @@ entt::entity prefabs::Bat::create(float pos_x_center, float pos_y_center)
     ScriptingComponent script(bat_script);
 
     HitpointComponent hitpoints(1);
-    hitpoints.add_observer(reinterpret_cast<Observer<DieEvent>*>(bat_script->get_observer()));
+    hitpoints.add_observer(reinterpret_cast<Observer<DeathEvent>*>(bat_script->get_observer()));
 
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<QuadComponent>(entity, quad);
@@ -233,6 +232,7 @@ entt::entity prefabs::Bat::create(float pos_x_center, float pos_y_center)
     registry.emplace<TakeProjectileDamageComponent>(entity);
     registry.emplace<TakeMeleeDamageComponent>(entity);
     registry.emplace<TakeJumpOnTopDamageComponent>(entity);
+    registry.emplace<NpcTypeComponent>(entity, NpcType::BAT);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/npc/Caveman.cpp
+++ b/src/game-loop/src/prefabs/npc/Caveman.cpp
@@ -10,6 +10,7 @@
 #include "components/generic/ScriptingComponent.hpp"
 #include "components/damage/HitpointComponent.hpp"
 #include "components/damage/TakeProjectileDamageComponent.hpp"
+#include "components/damage/TakeMeleeDamageComponent.hpp"
 
 #include "EntityRegistry.hpp"
 #include "TextureType.hpp"
@@ -185,6 +186,7 @@ entt::entity prefabs::Caveman::create(float pos_x_center, float pos_y_center)
     registry.emplace<ScriptingComponent>(entity, script);
     registry.emplace<HorizontalOrientationComponent>(entity);
     registry.emplace<TakeProjectileDamageComponent>(entity);
+    registry.emplace<TakeMeleeDamageComponent>(entity);
     registry.emplace<HitpointComponent>(entity, hitpoints);
 
     return entity;

--- a/src/game-loop/src/prefabs/npc/Caveman.cpp
+++ b/src/game-loop/src/prefabs/npc/Caveman.cpp
@@ -11,6 +11,7 @@
 #include "components/damage/HitpointComponent.hpp"
 #include "components/damage/TakeProjectileDamageComponent.hpp"
 #include "components/damage/TakeMeleeDamageComponent.hpp"
+#include "components/damage/TakeJumpOnTopDamage.hpp"
 
 #include "EntityRegistry.hpp"
 #include "TextureType.hpp"
@@ -187,6 +188,7 @@ entt::entity prefabs::Caveman::create(float pos_x_center, float pos_y_center)
     registry.emplace<TakeProjectileDamageComponent>(entity);
     registry.emplace<TakeMeleeDamageComponent>(entity);
     registry.emplace<HitpointComponent>(entity, hitpoints);
+    registry.emplace<TakeJumpOnTopDamageComponent>(entity);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/npc/Caveman.cpp
+++ b/src/game-loop/src/prefabs/npc/Caveman.cpp
@@ -34,25 +34,24 @@ namespace
             auto& registry = EntityRegistry::instance().get_registry();
             auto& position = registry.get<PositionComponent>(_caveman);
 
+            for (std::size_t index = 0; index < 4; index++)
             {
-                auto blood = prefabs::BloodParticle::create(position.x_center, position.y_center);
-                auto& physics = registry.get<PhysicsComponent>(blood);
-                physics.set_x_velocity(-0.1f);
-                physics.set_y_velocity(-0.1f);
-            }
+                auto particle = prefabs::BloodParticle::create(position.x_center, position.y_center);
+                auto& physics = registry.get<PhysicsComponent>(particle);
 
-            {
-                auto blood = prefabs::BloodParticle::create(position.x_center, position.y_center);
-                auto& physics = registry.get<PhysicsComponent>(blood);
-                physics.set_x_velocity(0.0f);
-                physics.set_y_velocity(-0.1f);
-            }
+                float v_x = static_cast<float>(std::rand() % 2) / 15.0f;
+                float v_y = static_cast<float>(std::rand() % 2) / 10.0f;
 
-            {
-                auto blood = prefabs::BloodParticle::create(position.x_center, position.y_center);
-                auto& physics = registry.get<PhysicsComponent>(blood);
-                physics.set_x_velocity(0.1f);
-                physics.set_y_velocity(-0.1f);
+                if (std::rand() % 2)
+                {
+                    v_x += 0.1f;
+                }
+                else
+                {
+                    v_x -= 0.1f;
+                }
+
+                physics.set_velocity(v_x, v_y);
             }
 
             registry.destroy(_caveman);

--- a/src/game-loop/src/prefabs/npc/Caveman.cpp
+++ b/src/game-loop/src/prefabs/npc/Caveman.cpp
@@ -1,6 +1,7 @@
 #include "prefabs/npc/Caveman.hpp"
 #include "prefabs/particles/BloodParticle.hpp"
 
+#include "components/generic/NpcTypeComponent.hpp"
 #include "components/generic/AnimationComponent.hpp"
 #include "components/generic/PhysicsComponent.hpp"
 #include "components/generic/PositionComponent.hpp"
@@ -24,13 +25,13 @@ namespace
     constexpr uint16_t max_waiting_time_ms = 3000;
     constexpr uint16_t max_walking_time_ms = 5000;
 
-    class CavemanDeathObserver final : public Observer<DieEvent>
+    class CavemanDeathObserver final : public Observer<DeathEvent>
     {
     public:
 
         explicit CavemanDeathObserver(entt::entity caveman) : _caveman(caveman) {}
 
-        void on_notify(const DieEvent*) override
+        void on_notify(const DeathEvent*) override
         {
             auto& registry = EntityRegistry::instance().get_registry();
             auto& position = registry.get<PositionComponent>(_caveman);
@@ -54,8 +55,6 @@ namespace
 
                 physics.set_velocity(v_x, v_y);
             }
-
-            registry.destroy(_caveman);
         }
 
     private:
@@ -176,7 +175,7 @@ entt::entity prefabs::Caveman::create(float pos_x_center, float pos_y_center)
     ScriptingComponent script(caveman_script);
 
     HitpointComponent hitpoints(1);
-    hitpoints.add_observer(reinterpret_cast<Observer<DieEvent>*>(caveman_script->get_observer()));
+    hitpoints.add_observer(reinterpret_cast<Observer<DeathEvent>*>(caveman_script->get_observer()));
 
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<QuadComponent>(entity, quad);
@@ -189,6 +188,7 @@ entt::entity prefabs::Caveman::create(float pos_x_center, float pos_y_center)
     registry.emplace<TakeMeleeDamageComponent>(entity);
     registry.emplace<HitpointComponent>(entity, hitpoints);
     registry.emplace<TakeJumpOnTopDamageComponent>(entity);
+    registry.emplace<NpcTypeComponent>(entity, NpcType::CAVEMAN);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/npc/Skeleton.cpp
+++ b/src/game-loop/src/prefabs/npc/Skeleton.cpp
@@ -4,6 +4,7 @@
 
 #include "components/specialized/MainDudeComponent.hpp"
 #include "components/generic/AnimationComponent.hpp"
+#include "components/generic/NpcTypeComponent.hpp"
 #include "components/generic/PhysicsComponent.hpp"
 #include "components/generic/PositionComponent.hpp"
 #include "components/generic/QuadComponent.hpp"
@@ -27,13 +28,13 @@ namespace
     constexpr float activation_distance_x = 3.0f;
     constexpr float activation_distance_y = 0.5f;
 
-    class SkeletonDeathObserver final : public Observer<DieEvent>
+    class SkeletonDeathObserver final : public Observer<DeathEvent>
     {
     public:
 
         explicit SkeletonDeathObserver(entt::entity skeleton) : _skeleton(skeleton) {}
 
-        void on_notify(const DieEvent*) override
+        void on_notify(const DeathEvent*) override
         {
             auto& registry = EntityRegistry::instance().get_registry();
             auto& position = registry.get<PositionComponent>(_skeleton);
@@ -45,7 +46,6 @@ namespace
             }
 
             prefabs::SmokePuffParticle::create(position.x_center, position.y_center);
-            registry.destroy(_skeleton);
         }
 
     private:
@@ -168,7 +168,7 @@ entt::entity prefabs::Skeleton::create(float pos_x_center, float pos_y_center)
     ScriptingComponent script(skeleton_script);
 
     HitpointComponent hitpoints(1);
-    hitpoints.add_observer(reinterpret_cast<Observer<DieEvent>*>(skeleton_script->get_observer()));
+    hitpoints.add_observer(reinterpret_cast<Observer<DeathEvent>*>(skeleton_script->get_observer()));
 
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<QuadComponent>(entity, quad);
@@ -182,6 +182,7 @@ entt::entity prefabs::Skeleton::create(float pos_x_center, float pos_y_center)
     registry.emplace<TakeProjectileDamageComponent>(entity);
     registry.emplace<TakeMeleeDamageComponent>(entity);
     registry.emplace<TakeJumpOnTopDamageComponent>(entity);
+    registry.emplace<NpcTypeComponent>(entity, NpcType::SKELETON);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/npc/Skeleton.cpp
+++ b/src/game-loop/src/prefabs/npc/Skeleton.cpp
@@ -11,6 +11,7 @@
 #include "components/generic/MeshComponent.hpp"
 #include "components/generic/ScriptingComponent.hpp"
 #include "components/damage/TakeFallDamageComponent.hpp"
+#include "components/damage/TakeProjectileDamageComponent.hpp"
 #include "components/damage/HitpointComponent.hpp"
 
 #include "EntityRegistry.hpp"
@@ -176,6 +177,7 @@ entt::entity prefabs::Skeleton::create(float pos_x_center, float pos_y_center)
     registry.emplace<HorizontalOrientationComponent>(entity);
     registry.emplace<HitpointComponent>(entity, hitpoints);
     registry.emplace<TakeFallDamageComponent>(entity, 1);
+    registry.emplace<TakeProjectileDamageComponent>(entity);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/npc/Skeleton.cpp
+++ b/src/game-loop/src/prefabs/npc/Skeleton.cpp
@@ -1,4 +1,6 @@
  #include "prefabs/npc/Skeleton.hpp"
+ #include "prefabs/particles/BonesParticle.hpp"
+ #include "prefabs/particles/SmokePuffParticle.hpp"
 
 #include "components/specialized/MainDudeComponent.hpp"
 #include "components/generic/AnimationComponent.hpp"
@@ -8,6 +10,8 @@
 #include "components/generic/HorizontalOrientationComponent.hpp"
 #include "components/generic/MeshComponent.hpp"
 #include "components/generic/ScriptingComponent.hpp"
+#include "components/damage/TakeFallDamageComponent.hpp"
+#include "components/damage/HitpointComponent.hpp"
 
 #include "EntityRegistry.hpp"
 #include "TextureType.hpp"
@@ -20,9 +24,42 @@ namespace
     constexpr float activation_distance_x = 3.0f;
     constexpr float activation_distance_y = 0.5f;
 
+    class SkeletonDeathObserver final : public Observer<DieEvent>
+    {
+    public:
+
+        explicit SkeletonDeathObserver(entt::entity skeleton) : _skeleton(skeleton) {}
+
+        void on_notify(const DieEvent*) override
+        {
+            auto& registry = EntityRegistry::instance().get_registry();
+            auto& position = registry.get<PositionComponent>(_skeleton);
+
+            auto bones = prefabs::BonesParticle::create(position.x_center, position.y_center);
+            {
+                auto& physics = registry.get<PhysicsComponent>(bones);
+                physics.set_y_velocity(-0.1f);
+            }
+
+            prefabs::SmokePuffParticle::create(position.x_center, position.y_center);
+            registry.destroy(_skeleton);
+        }
+
+    private:
+        const entt::entity _skeleton;
+    };
+
     class SkeletonScript final : public ScriptBase
     {
     public:
+
+        explicit SkeletonScript(entt::entity skeleton) : _death_observer(skeleton) {}
+
+        SkeletonDeathObserver* get_observer()
+        {
+            return &_death_observer;
+        }
+
         void update(entt::entity owner, uint32_t delta_time_ms) override
         {
             auto& registry = EntityRegistry::instance().get_registry();
@@ -99,6 +136,7 @@ namespace
             }
         }
     private:
+        SkeletonDeathObserver _death_observer;
         bool _started_transformation = false;
         bool _finished_transformation = false;
         HorizontalOrientation _orientation;
@@ -123,13 +161,21 @@ entt::entity prefabs::Skeleton::create(float pos_x_center, float pos_y_center)
     QuadComponent quad(TextureType::NPC, width, height);
     quad.frame_changed(NPCSpritesheetFrames::SKELETON_CREATE_0_FIRST);
 
+    auto skeleton_script = std::make_shared<SkeletonScript>(entity);
+    ScriptingComponent script(skeleton_script);
+
+    HitpointComponent hitpoints(1);
+    hitpoints.add_observer(reinterpret_cast<Observer<DieEvent>*>(skeleton_script->get_observer()));
+
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<QuadComponent>(entity, quad);
     registry.emplace<AnimationComponent>(entity);
     registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_2_ITEMS, CameraType::MODEL_VIEW_SPACE);
     registry.emplace<PhysicsComponent>(entity, width - (4.0f / 16.0f), height - (2.0f / 16.0f));
-    registry.emplace<ScriptingComponent>(entity, std::make_shared<SkeletonScript>());
+    registry.emplace<ScriptingComponent>(entity, script);
     registry.emplace<HorizontalOrientationComponent>(entity);
+    registry.emplace<HitpointComponent>(entity, hitpoints);
+    registry.emplace<TakeFallDamageComponent>(entity, 1);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/npc/Skeleton.cpp
+++ b/src/game-loop/src/prefabs/npc/Skeleton.cpp
@@ -14,6 +14,7 @@
 #include "components/damage/TakeProjectileDamageComponent.hpp"
 #include "components/damage/HitpointComponent.hpp"
 #include "components/damage/TakeMeleeDamageComponent.hpp"
+#include "components/damage/TakeJumpOnTopDamage.hpp"
 
 #include "EntityRegistry.hpp"
 #include "TextureType.hpp"
@@ -180,6 +181,7 @@ entt::entity prefabs::Skeleton::create(float pos_x_center, float pos_y_center)
     registry.emplace<TakeFallDamageComponent>(entity, 1);
     registry.emplace<TakeProjectileDamageComponent>(entity);
     registry.emplace<TakeMeleeDamageComponent>(entity);
+    registry.emplace<TakeJumpOnTopDamageComponent>(entity);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/npc/Skeleton.cpp
+++ b/src/game-loop/src/prefabs/npc/Skeleton.cpp
@@ -13,6 +13,7 @@
 #include "components/damage/TakeFallDamageComponent.hpp"
 #include "components/damage/TakeProjectileDamageComponent.hpp"
 #include "components/damage/HitpointComponent.hpp"
+#include "components/damage/TakeMeleeDamageComponent.hpp"
 
 #include "EntityRegistry.hpp"
 #include "TextureType.hpp"
@@ -178,6 +179,7 @@ entt::entity prefabs::Skeleton::create(float pos_x_center, float pos_y_center)
     registry.emplace<HitpointComponent>(entity, hitpoints);
     registry.emplace<TakeFallDamageComponent>(entity, 1);
     registry.emplace<TakeProjectileDamageComponent>(entity);
+    registry.emplace<TakeMeleeDamageComponent>(entity);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/npc/Snake.cpp
+++ b/src/game-loop/src/prefabs/npc/Snake.cpp
@@ -34,25 +34,24 @@ namespace
             auto& registry = EntityRegistry::instance().get_registry();
             auto& position = registry.get<PositionComponent>(_snake);
 
+            for (std::size_t index = 0; index < 4; index++)
             {
-                auto blood = prefabs::BloodParticle::create(position.x_center, position.y_center);
-                auto& physics = registry.get<PhysicsComponent>(blood);
-                physics.set_x_velocity(-0.1f);
-                physics.set_y_velocity(-0.1f);
-            }
+                auto particle = prefabs::BloodParticle::create(position.x_center, position.y_center);
+                auto& physics = registry.get<PhysicsComponent>(particle);
 
-            {
-                auto blood = prefabs::BloodParticle::create(position.x_center, position.y_center);
-                auto& physics = registry.get<PhysicsComponent>(blood);
-                physics.set_x_velocity(0.0f);
-                physics.set_y_velocity(-0.1f);
-            }
+                float v_x = static_cast<float>(std::rand() % 2) / 15.0f;
+                float v_y = static_cast<float>(std::rand() % 2) / 10.0f;
 
-            {
-                auto blood = prefabs::BloodParticle::create(position.x_center, position.y_center);
-                auto& physics = registry.get<PhysicsComponent>(blood);
-                physics.set_x_velocity(0.1f);
-                physics.set_y_velocity(-0.1f);
+                if (std::rand() % 2)
+                {
+                    v_x += 0.1f;
+                }
+                else
+                {
+                    v_x -= 0.1f;
+                }
+
+                physics.set_velocity(v_x, v_y);
             }
 
             registry.destroy(_snake);

--- a/src/game-loop/src/prefabs/npc/Snake.cpp
+++ b/src/game-loop/src/prefabs/npc/Snake.cpp
@@ -55,9 +55,6 @@ namespace
 
                 physics.set_velocity(v_x, v_y);
             }
-
-//            auto& hitpoints = registry.get<HitpointComponent>(_snake);
-//            hitpoints.remove_observer(this);
         }
 
     private:

--- a/src/game-loop/src/prefabs/npc/Snake.cpp
+++ b/src/game-loop/src/prefabs/npc/Snake.cpp
@@ -176,8 +176,7 @@ entt::entity prefabs::Snake::create(float pos_x_center, float pos_y_center)
     auto snake_script = std::make_shared<SnakeScript>(entity);
     ScriptingComponent script(snake_script);
 
-    HitpointComponent hitpoints(1);
-    hitpoints.add_observer(reinterpret_cast<Observer<DieEvent>*>(snake_script->get_observer()));
+    HitpointComponent hitpoints(1);hitpoints.add_observer(reinterpret_cast<Observer<DieEvent>*>(snake_script->get_observer()));
 
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<QuadComponent>(entity, quad);

--- a/src/game-loop/src/prefabs/npc/Snake.cpp
+++ b/src/game-loop/src/prefabs/npc/Snake.cpp
@@ -10,6 +10,7 @@
 #include "components/generic/ScriptingComponent.hpp"
 #include "components/damage/HitpointComponent.hpp"
 #include "components/damage/TakeProjectileDamageComponent.hpp"
+#include "components/damage/TakeMeleeDamageComponent.hpp"
 
 #include "EntityRegistry.hpp"
 #include "TextureType.hpp"
@@ -187,6 +188,7 @@ entt::entity prefabs::Snake::create(float pos_x_center, float pos_y_center)
     registry.emplace<HorizontalOrientationComponent>(entity);
     registry.emplace<HitpointComponent>(entity, hitpoints);
     registry.emplace<TakeProjectileDamageComponent>(entity);
+    registry.emplace<TakeMeleeDamageComponent>(entity);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/npc/Snake.cpp
+++ b/src/game-loop/src/prefabs/npc/Snake.cpp
@@ -2,6 +2,7 @@
 #include "prefabs/particles/BloodParticle.hpp"
 
 #include "components/generic/AnimationComponent.hpp"
+#include "components/generic/NpcTypeComponent.hpp"
 #include "components/generic/PhysicsComponent.hpp"
 #include "components/generic/PositionComponent.hpp"
 #include "components/generic/QuadComponent.hpp"
@@ -24,13 +25,13 @@ namespace
     constexpr uint16_t max_waiting_time_ms = 3000;
     constexpr uint16_t max_walking_time_ms = 5000;
 
-    class SnakeDeathObserver final : public Observer<DieEvent>
+    class SnakeDeathObserver final : public Observer<DeathEvent>
     {
     public:
 
         explicit SnakeDeathObserver(entt::entity snake) : _snake(snake) {}
 
-        void on_notify(const DieEvent*) override
+        void on_notify(const DeathEvent*) override
         {
             auto& registry = EntityRegistry::instance().get_registry();
             auto& position = registry.get<PositionComponent>(_snake);
@@ -55,7 +56,8 @@ namespace
                 physics.set_velocity(v_x, v_y);
             }
 
-            registry.destroy(_snake);
+//            auto& hitpoints = registry.get<HitpointComponent>(_snake);
+//            hitpoints.remove_observer(this);
         }
 
     private:
@@ -176,7 +178,8 @@ entt::entity prefabs::Snake::create(float pos_x_center, float pos_y_center)
     auto snake_script = std::make_shared<SnakeScript>(entity);
     ScriptingComponent script(snake_script);
 
-    HitpointComponent hitpoints(1);hitpoints.add_observer(reinterpret_cast<Observer<DieEvent>*>(snake_script->get_observer()));
+    HitpointComponent hitpoints(1);
+    hitpoints.add_observer(reinterpret_cast<Observer<DeathEvent>*>(snake_script->get_observer()));
 
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<QuadComponent>(entity, quad);
@@ -189,6 +192,7 @@ entt::entity prefabs::Snake::create(float pos_x_center, float pos_y_center)
     registry.emplace<TakeProjectileDamageComponent>(entity);
     registry.emplace<TakeMeleeDamageComponent>(entity);
     registry.emplace<TakeJumpOnTopDamageComponent>(entity);
+    registry.emplace<NpcTypeComponent>(entity, NpcType::SNAKE);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/npc/Snake.cpp
+++ b/src/game-loop/src/prefabs/npc/Snake.cpp
@@ -11,6 +11,7 @@
 #include "components/damage/HitpointComponent.hpp"
 #include "components/damage/TakeProjectileDamageComponent.hpp"
 #include "components/damage/TakeMeleeDamageComponent.hpp"
+#include "components/damage/TakeJumpOnTopDamage.hpp"
 
 #include "EntityRegistry.hpp"
 #include "TextureType.hpp"
@@ -187,6 +188,7 @@ entt::entity prefabs::Snake::create(float pos_x_center, float pos_y_center)
     registry.emplace<HitpointComponent>(entity, hitpoints);
     registry.emplace<TakeProjectileDamageComponent>(entity);
     registry.emplace<TakeMeleeDamageComponent>(entity);
+    registry.emplace<TakeJumpOnTopDamageComponent>(entity);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/npc/Spider.cpp
+++ b/src/game-loop/src/prefabs/npc/Spider.cpp
@@ -68,7 +68,10 @@ namespace
     {
     public:
 
-        explicit SpiderScript(entt::entity spider) : _death_observer(spider) {}
+        explicit SpiderScript(entt::entity spider)
+            : _death_observer(spider)
+        {
+        }
 
         SpiderDeathObserver* get_observer()
         {
@@ -103,17 +106,7 @@ namespace
 
                     if (!_triggered)
                     {
-                        _triggered = true;
-
-                        auto &quad = registry.get<QuadComponent>(owner);
-                        auto &animation = registry.get<AnimationComponent>(owner);
-                        auto &physics = registry.get<PhysicsComponent>(owner);
-
-                        physics.enable_gravity();
-                        quad.frame_changed(NPCSpritesheetFrames::SPIDER_FLIP_0_FIRST);
-                        animation.start(static_cast<std::size_t>(NPCSpritesheetFrames::SPIDER_FLIP_0_FIRST),
-                                        static_cast<std::size_t>(NPCSpritesheetFrames::SPIDER_FLIP_8_LAST),
-                                        100, false);
+                        trigger(owner);
                     }
                 }
             });
@@ -155,7 +148,26 @@ namespace
                 }
             }
         }
+
+        void trigger(entt::entity owner)
+        {
+            _triggered = true;
+
+            auto& registry = EntityRegistry::instance().get_registry();
+
+            auto &quad = registry.get<QuadComponent>(owner);
+            auto &animation = registry.get<AnimationComponent>(owner);
+            auto &physics = registry.get<PhysicsComponent>(owner);
+
+            physics.enable_gravity();
+            quad.frame_changed(NPCSpritesheetFrames::SPIDER_FLIP_0_FIRST);
+            animation.start(static_cast<std::size_t>(NPCSpritesheetFrames::SPIDER_FLIP_0_FIRST),
+                            static_cast<std::size_t>(NPCSpritesheetFrames::SPIDER_FLIP_8_LAST),
+                            100, false);
+        }
+
     private:
+
         SpiderDeathObserver _death_observer;
         bool _triggered = false;
         bool _flipping_animation_finished = false;
@@ -170,7 +182,7 @@ entt::entity prefabs::Spider::create()
     return create(0, 0);
 }
 
-entt::entity prefabs::Spider::create(float pos_x_center, float pos_y_center)
+entt::entity prefabs::Spider::create(float pos_x_center, float pos_y_center, bool triggered)
 {
     auto& registry = EntityRegistry::instance().get_registry();
 
@@ -203,6 +215,11 @@ entt::entity prefabs::Spider::create(float pos_x_center, float pos_y_center)
     registry.emplace<HitpointComponent>(entity, hitpoints);
     registry.emplace<TakeProjectileDamageComponent>(entity);
     registry.emplace<TakeMeleeDamageComponent>(entity);
+
+    if (triggered)
+    {
+        spider_script->trigger(entity);
+    }
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/npc/Spider.cpp
+++ b/src/game-loop/src/prefabs/npc/Spider.cpp
@@ -11,6 +11,7 @@
 #include "components/generic/ScriptingComponent.hpp"
 #include "components/damage/HitpointComponent.hpp"
 #include "components/damage/TakeProjectileDamageComponent.hpp"
+#include "components/damage/TakeMeleeDamageComponent.hpp"
 
 #include "EntityRegistry.hpp"
 #include "TextureType.hpp"
@@ -201,6 +202,7 @@ entt::entity prefabs::Spider::create(float pos_x_center, float pos_y_center)
     registry.emplace<HorizontalOrientationComponent>(entity);
     registry.emplace<HitpointComponent>(entity, hitpoints);
     registry.emplace<TakeProjectileDamageComponent>(entity);
+    registry.emplace<TakeMeleeDamageComponent>(entity);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/npc/Spider.cpp
+++ b/src/game-loop/src/prefabs/npc/Spider.cpp
@@ -2,6 +2,7 @@
 #include "prefabs/particles/BloodParticle.hpp"
 
 #include "components/specialized/MainDudeComponent.hpp"
+#include "components/generic/NpcTypeComponent.hpp"
 #include "components/generic/AnimationComponent.hpp"
 #include "components/generic/PhysicsComponent.hpp"
 #include "components/generic/PositionComponent.hpp"
@@ -26,13 +27,13 @@ namespace
     constexpr float activation_distance_y = 7;
     constexpr uint32_t update_delta_ms = 20;
    
-    class SpiderDeathObserver final : public Observer<DieEvent>
+    class SpiderDeathObserver final : public Observer<DeathEvent>
     {
     public:
 
         explicit SpiderDeathObserver(entt::entity Spider) : _spider(Spider) {}
 
-        void on_notify(const DieEvent*) override
+        void on_notify(const DeathEvent*) override
         {
             auto& registry = EntityRegistry::instance().get_registry();
             auto& position = registry.get<PositionComponent>(_spider);
@@ -56,8 +57,6 @@ namespace
 
                 physics.set_velocity(v_x, v_y);
             }
-
-            registry.destroy(_spider);
         }
 
     private:
@@ -203,7 +202,7 @@ entt::entity prefabs::Spider::create(float pos_x_center, float pos_y_center, boo
     ScriptingComponent script(spider_script);
 
     HitpointComponent hitpoints(1);
-    hitpoints.add_observer(reinterpret_cast<Observer<DieEvent>*>(spider_script->get_observer()));
+    hitpoints.add_observer(reinterpret_cast<Observer<DeathEvent>*>(spider_script->get_observer()));
 
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<QuadComponent>(entity, quad);
@@ -216,6 +215,7 @@ entt::entity prefabs::Spider::create(float pos_x_center, float pos_y_center, boo
     registry.emplace<TakeProjectileDamageComponent>(entity);
     registry.emplace<TakeMeleeDamageComponent>(entity);
     registry.emplace<TakeJumpOnTopDamageComponent>(entity);
+    registry.emplace<NpcTypeComponent>(entity, NpcType::SPIDER);
 
     if (triggered)
     {

--- a/src/game-loop/src/prefabs/npc/Spider.cpp
+++ b/src/game-loop/src/prefabs/npc/Spider.cpp
@@ -36,25 +36,24 @@ namespace
             auto& registry = EntityRegistry::instance().get_registry();
             auto& position = registry.get<PositionComponent>(_spider);
 
+            for (std::size_t index = 0; index < 4; index++)
             {
-                auto blood = prefabs::BloodParticle::create(position.x_center, position.y_center);
-                auto& physics = registry.get<PhysicsComponent>(blood);
-                physics.set_x_velocity(-0.1f);
-                physics.set_y_velocity(-0.1f);
-            }
+                auto particle = prefabs::BloodParticle::create(position.x_center, position.y_center);
+                auto& physics = registry.get<PhysicsComponent>(particle);
 
-            {
-                auto blood = prefabs::BloodParticle::create(position.x_center, position.y_center);
-                auto& physics = registry.get<PhysicsComponent>(blood);
-                physics.set_x_velocity(0.0f);
-                physics.set_y_velocity(-0.1f);
-            }
+                float v_x = static_cast<float>(std::rand() % 2) / 15.0f;
+                float v_y = static_cast<float>(std::rand() % 2) / 10.0f;
 
-            {
-                auto blood = prefabs::BloodParticle::create(position.x_center, position.y_center);
-                auto& physics = registry.get<PhysicsComponent>(blood);
-                physics.set_x_velocity(0.1f);
-                physics.set_y_velocity(-0.1f);
+                if (std::rand() % 2)
+                {
+                    v_x += 0.1f;
+                }
+                else
+                {
+                    v_x -= 0.1f;
+                }
+
+                physics.set_velocity(v_x, v_y);
             }
 
             registry.destroy(_spider);

--- a/src/game-loop/src/prefabs/npc/Spider.cpp
+++ b/src/game-loop/src/prefabs/npc/Spider.cpp
@@ -12,6 +12,7 @@
 #include "components/damage/HitpointComponent.hpp"
 #include "components/damage/TakeProjectileDamageComponent.hpp"
 #include "components/damage/TakeMeleeDamageComponent.hpp"
+#include "components/damage/TakeJumpOnTopDamage.hpp"
 
 #include "EntityRegistry.hpp"
 #include "TextureType.hpp"
@@ -214,6 +215,7 @@ entt::entity prefabs::Spider::create(float pos_x_center, float pos_y_center, boo
     registry.emplace<HitpointComponent>(entity, hitpoints);
     registry.emplace<TakeProjectileDamageComponent>(entity);
     registry.emplace<TakeMeleeDamageComponent>(entity);
+    registry.emplace<TakeJumpOnTopDamageComponent>(entity);
 
     if (triggered)
     {

--- a/src/game-loop/src/prefabs/other/Bullet.cpp
+++ b/src/game-loop/src/prefabs/other/Bullet.cpp
@@ -17,23 +17,18 @@
 
 namespace
 {
-    class BulletDeathObserver final : public Observer<DieEvent>
+    class BulletDeathObserver final : public Observer<DeathEvent>
     {
     public:
 
         explicit BulletDeathObserver(entt::entity bullet) :_bullet(bullet) {}
 
-        void on_notify(const DieEvent*) override
+        void on_notify(const DeathEvent*) override
         {
             auto& registry = EntityRegistry::instance().get_registry();
             auto& position = registry.get<PositionComponent>(_bullet);
 
             prefabs::SmokePuffParticle::create(position.x_center, position.y_center);
-
-            auto& hitpoints = registry.get<HitpointComponent>(_bullet);
-            hitpoints.remove_observer(this);
-
-            registry.destroy(_bullet);
         }
 
     private:
@@ -98,7 +93,7 @@ entt::entity prefabs::Bullet::create(float pos_x_center, float pos_y_center)
     ScriptingComponent script(bullet_script);
 
     HitpointComponent hitpoints(1);
-    hitpoints.add_observer(reinterpret_cast<Observer<DieEvent>*>(bullet_script->get_observer()));
+    hitpoints.add_observer(reinterpret_cast<Observer<DeathEvent>*>(bullet_script->get_observer()));
 
     GiveProjectileDamageComponent give_projectile_damage(2);
     give_projectile_damage.set_mutual(true);

--- a/src/game-loop/src/prefabs/other/Bullet.cpp
+++ b/src/game-loop/src/prefabs/other/Bullet.cpp
@@ -47,17 +47,6 @@ namespace
 
         void update(entt::entity owner, uint32_t delta_time_ms) override
         {
-            auto& registry = EntityRegistry::instance().get_registry();
-            auto& physics = registry.get<PhysicsComponent>(owner);
-
-            // TODO: Jar / Bullet / Bullet - destroyed on hit wall
-            if (physics.is_left_collision() || physics.is_right_collision() ||
-                physics.is_upper_collision() || physics.is_bottom_collision())
-            {
-                auto& position = registry.get<PositionComponent>(owner);
-                prefabs::SmokePuffParticle::create(position.x_center, position.y_center);
-                registry.destroy(owner);
-            }
         }
     private:
         BulletDeathObserver _death_observer;

--- a/src/game-loop/src/prefabs/other/Bullet.cpp
+++ b/src/game-loop/src/prefabs/other/Bullet.cpp
@@ -2,6 +2,7 @@
 #include "prefabs/particles/SmokePuffParticle.hpp"
 
 #include "components/generic/PhysicsComponent.hpp"
+#include "components/damage/GiveProjectileDamageComponent.hpp"
 #include "components/generic/HorizontalOrientationComponent.hpp"
 #include "components/generic/PositionComponent.hpp"
 #include "components/generic/ScriptingComponent.hpp"
@@ -64,6 +65,7 @@ entt::entity prefabs::Bullet::create(float pos_x_center, float pos_y_center)
     registry.emplace<PhysicsComponent>(entity, physics);
     registry.emplace<HorizontalOrientationComponent>(entity);
     registry.emplace<ScriptingComponent>(entity, std::make_shared<BulletScript>());
+    registry.emplace<GiveProjectileDamageComponent>(entity, 1);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/particles/BloodParticle.cpp
+++ b/src/game-loop/src/prefabs/particles/BloodParticle.cpp
@@ -1,6 +1,7 @@
 #include "prefabs/particles/BloodParticle.hpp"
 
 #include "components/generic/PositionComponent.hpp"
+#include "components/generic/ParticleEmitterComponent.hpp"
 #include "components/generic/PhysicsComponent.hpp"
 #include "components/generic/QuadComponent.hpp"
 #include "components/generic/MeshComponent.hpp"
@@ -27,7 +28,7 @@ entt::entity prefabs::BloodParticle::create(float pos_x_center, float pos_y_cent
 
     PhysicsComponent physics(width, height);
     physics.set_gravity_modifier(0.4f);
-    physics.set_bounciness(0.6f);
+    physics.set_bounciness(0.8f);
 
     QuadComponent quad(TextureType::COLLECTIBLES, width, height);
     quad.frame_changed<CollectiblesSpritesheetFrames>(CollectiblesSpritesheetFrames::BLOOD_TRAIL_0_FIRST);
@@ -41,12 +42,18 @@ entt::entity prefabs::BloodParticle::create(float pos_x_center, float pos_y_cent
     mesh.rendering_layer = RenderingLayer::LAYER_3_DUDE;
     mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
 
+    ParticleEmitterComponent emitter;
+    emitter.interval_ms = 250;
+    emitter.particle_type = ParticleType::BLOOD_TRAIL;
+    emitter.time_since_last_emission_ms = 0;
+
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<QuadComponent>(entity, quad);
     registry.emplace<MeshComponent>(entity, mesh);
     registry.emplace<PhysicsComponent>(entity, physics);
     registry.emplace<AnimationComponent>(entity, animation);
-    registry.emplace<TimeLimitComponent>(entity, 750);
+    registry.emplace<TimeLimitComponent>(entity, 2500);
+    registry.emplace<ParticleEmitterComponent>(entity, emitter);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/particles/BloodParticle.cpp
+++ b/src/game-loop/src/prefabs/particles/BloodParticle.cpp
@@ -36,7 +36,7 @@ entt::entity prefabs::BloodParticle::create(float pos_x_center, float pos_y_cent
     AnimationComponent animation;
     animation.start(static_cast<std::size_t>(CollectiblesSpritesheetFrames::BLOOD_TRAIL_0_FIRST),
                     static_cast<std::size_t>(CollectiblesSpritesheetFrames::BLOOD_TRAIL_6_LAST),
-                    110, false);
+                    110, true);
 
     MeshComponent mesh;
     mesh.rendering_layer = RenderingLayer::LAYER_3_DUDE;
@@ -52,7 +52,7 @@ entt::entity prefabs::BloodParticle::create(float pos_x_center, float pos_y_cent
     registry.emplace<MeshComponent>(entity, mesh);
     registry.emplace<PhysicsComponent>(entity, physics);
     registry.emplace<AnimationComponent>(entity, animation);
-    registry.emplace<TimeLimitComponent>(entity, 2500);
+    registry.emplace<TimeLimitComponent>(entity, 1500);
     registry.emplace<ParticleEmitterComponent>(entity, emitter);
 
     return entity;

--- a/src/game-loop/src/prefabs/particles/BloodParticle.cpp
+++ b/src/game-loop/src/prefabs/particles/BloodParticle.cpp
@@ -1,0 +1,52 @@
+#include "prefabs/particles/BloodParticle.hpp"
+
+#include "components/generic/PositionComponent.hpp"
+#include "components/generic/PhysicsComponent.hpp"
+#include "components/generic/QuadComponent.hpp"
+#include "components/generic/MeshComponent.hpp"
+#include "components/generic/AnimationComponent.hpp"
+#include "components/generic/TimeLimitComponent.hpp"
+
+#include "EntityRegistry.hpp"
+#include "TextureType.hpp"
+#include "spritesheet-frames/CollectiblesSpritesheetFrames.hpp"
+
+entt::entity prefabs::BloodParticle::create()
+{
+    return create(0, 0);
+}
+
+entt::entity prefabs::BloodParticle::create(float pos_x_center, float pos_y_center)
+{
+    auto& registry = EntityRegistry::instance().get_registry();
+
+    const auto entity = registry.create();
+
+    const float width = 0.5f;
+    const float height = 0.5f;
+
+    PhysicsComponent physics(width, height);
+    physics.set_gravity_modifier(0.4f);
+    physics.set_bounciness(0.6f);
+
+    QuadComponent quad(TextureType::COLLECTIBLES, width, height);
+    quad.frame_changed<CollectiblesSpritesheetFrames>(CollectiblesSpritesheetFrames::BLOOD_TRAIL_0_FIRST);
+
+    AnimationComponent animation;
+    animation.start(static_cast<std::size_t>(CollectiblesSpritesheetFrames::BLOOD_TRAIL_0_FIRST),
+                    static_cast<std::size_t>(CollectiblesSpritesheetFrames::BLOOD_TRAIL_6_LAST),
+                    110, false);
+
+    MeshComponent mesh;
+    mesh.rendering_layer = RenderingLayer::LAYER_3_DUDE;
+    mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
+
+    registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
+    registry.emplace<QuadComponent>(entity, quad);
+    registry.emplace<MeshComponent>(entity, mesh);
+    registry.emplace<PhysicsComponent>(entity, physics);
+    registry.emplace<AnimationComponent>(entity, animation);
+    registry.emplace<TimeLimitComponent>(entity, 750);
+
+    return entity;
+}

--- a/src/game-loop/src/prefabs/particles/BloodTrailParticle.cpp
+++ b/src/game-loop/src/prefabs/particles/BloodTrailParticle.cpp
@@ -39,7 +39,7 @@ entt::entity prefabs::BloodTrailParticle::create(float pos_x_center, float pos_y
     registry.emplace<QuadComponent>(entity, quad);
     registry.emplace<MeshComponent>(entity, mesh);
     registry.emplace<AnimationComponent>(entity, animation);
-    registry.emplace<TimeLimitComponent>(entity, 750);
+    registry.emplace<TimeLimitComponent>(entity, 700);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/particles/BloodTrailParticle.cpp
+++ b/src/game-loop/src/prefabs/particles/BloodTrailParticle.cpp
@@ -39,7 +39,7 @@ entt::entity prefabs::BloodTrailParticle::create(float pos_x_center, float pos_y
     registry.emplace<QuadComponent>(entity, quad);
     registry.emplace<MeshComponent>(entity, mesh);
     registry.emplace<AnimationComponent>(entity, animation);
-    registry.emplace<TimeLimitComponent>(entity, 700);
+    registry.emplace<TimeLimitComponent>(entity, 750);
 
     return entity;
 }

--- a/src/game-loop/src/system/DamageSystem.cpp
+++ b/src/game-loop/src/system/DamageSystem.cpp
@@ -1,0 +1,36 @@
+#include "system/DamageSystem.hpp"
+#include "components/damage/TakeFallDamageComponent.hpp"
+#include "components/generic/PhysicsComponent.hpp"
+#include "components/damage/HitpointComponent.hpp"
+#include "EntityRegistry.hpp"
+#include "audio/Audio.hpp"
+
+void DamageSystem::update(std::uint32_t delta_time_ms)
+{
+    update_falling_damage();
+}
+
+void DamageSystem::update_falling_damage()
+{
+    auto &registry = EntityRegistry::instance().get_registry();
+    auto bodies = registry.view<TakeFallDamageComponent, HitpointComponent, PhysicsComponent>();
+
+    auto give_fall_damage = [](TakeFallDamageComponent& fall_damage, HitpointComponent& hitpoints, PhysicsComponent& physics)
+    {
+        const bool damage_taken = fall_damage.update(physics);
+        if (damage_taken)
+        {
+            const FallDamage_t damage = fall_damage.get_falling_damage();
+
+            fall_damage.notify(damage);
+            hitpoints.remove_hitpoints(damage);
+
+            if (hitpoints.get_hitpoints() <= 0)
+            {
+                hitpoints.notify({});
+            }
+        }
+    };
+
+    registry.view<TakeFallDamageComponent, HitpointComponent, PhysicsComponent>().each(give_fall_damage);
+}

--- a/src/game-loop/src/system/DamageSystem.cpp
+++ b/src/game-loop/src/system/DamageSystem.cpp
@@ -2,12 +2,56 @@
 #include "components/damage/TakeFallDamageComponent.hpp"
 #include "components/generic/PhysicsComponent.hpp"
 #include "components/damage/HitpointComponent.hpp"
+#include "components/damage/TakeProjectileDamageComponent.hpp"
+#include "components/damage/GiveProjectileDamageComponent.hpp"
 #include "EntityRegistry.hpp"
 #include "audio/Audio.hpp"
 
 void DamageSystem::update(std::uint32_t delta_time_ms)
 {
     update_falling_damage();
+    update_projectile_damage();
+}
+
+void DamageSystem::update_projectile_damage()
+{
+    auto &registry = EntityRegistry::instance().get_registry();
+    auto bodies = registry.view<TakeProjectileDamageComponent, HitpointComponent, PhysicsComponent, PositionComponent>();
+    auto projectiles = registry.view<GiveProjectileDamageComponent, PhysicsComponent, PositionComponent>();
+
+    auto give_projectile_damage = [&bodies](GiveProjectileDamageComponent& give_damage,
+                                            PhysicsComponent& projectile_physics,
+                                            PositionComponent& projectile_position)
+    {
+        if (projectile_physics.get_x_velocity() == 0.0f && projectile_physics.get_y_velocity() == 0.0f)
+        {
+            return;
+        }
+
+        bodies.each([&projectile_physics, &projectile_position, &give_damage](
+                        TakeProjectileDamageComponent& take_damage,
+                        HitpointComponent& hitpoints,
+                        PhysicsComponent& body_physics,
+                        PositionComponent& body_position)
+        {
+            if (!body_physics.is_collision(projectile_physics, projectile_position, body_position))
+            {
+                return;
+            }
+
+            const ProjectileDamage_t damage = give_damage.get_damage();
+
+            take_damage.notify(damage);
+            hitpoints.remove_hitpoints(damage);
+
+            if (hitpoints.get_hitpoints() <= 0)
+            {
+                hitpoints.notify({});
+            }
+        });
+    };
+
+    registry.view<GiveProjectileDamageComponent, PhysicsComponent, PositionComponent>().each(give_projectile_damage);
 }
 
 void DamageSystem::update_falling_damage()

--- a/src/game-loop/src/system/DamageSystem.cpp
+++ b/src/game-loop/src/system/DamageSystem.cpp
@@ -2,6 +2,8 @@
 #include "components/damage/TakeFallDamageComponent.hpp"
 #include "components/generic/PhysicsComponent.hpp"
 #include "components/damage/HitpointComponent.hpp"
+#include "components/damage/TakeJumpOnTopDamage.hpp"
+#include "components/damage/GiveJumpOnTopDamage.hpp"
 #include "components/damage/TakeProjectileDamageComponent.hpp"
 #include "components/damage/TakeTileCollisionDamageComponent.hpp"
 #include "components/damage/GiveProjectileDamageComponent.hpp"
@@ -29,6 +31,7 @@ void DamageSystem::update(std::uint32_t delta_time_ms)
     update_falling_damage();
     update_projectile_damage();
     update_melee_damage();
+    update_jump_on_top_damage();
 }
 
 void DamageSystem::update_melee_damage()
@@ -182,4 +185,57 @@ void DamageSystem::update_tile_collision_damage()
     };
 
     registry.view<TakeTileCollisionDamageComponent, HitpointComponent, PhysicsComponent>().each(give_tile_collision_damage);
+}
+
+void DamageSystem::update_jump_on_top_damage()
+{
+    auto &registry = EntityRegistry::instance().get_registry();
+    auto bodies = registry.view<TakeJumpOnTopDamageComponent, HitpointComponent, PhysicsComponent, PositionComponent>();
+    auto jumping_bodies = registry.view<GiveJumpOnTopDamageComponent, PhysicsComponent, PositionComponent>();
+
+    auto give_jump_on_top_damage = [&bodies](entt::entity give_damage_entity,
+                                             GiveJumpOnTopDamageComponent& give_damage,
+                                             PhysicsComponent& jumping_physics,
+                                             PositionComponent& jumping_position)
+    {
+        if (jumping_physics.get_y_velocity() <= 0.0f)
+        {
+            return;
+        }
+
+        bodies.each([&](entt::entity take_damage_entity,
+                             TakeJumpOnTopDamageComponent& take_damage,
+                             HitpointComponent& hitpoints,
+                             PhysicsComponent& body_physics,
+                             PositionComponent& body_position)
+        {
+            if (jumping_physics.get_y_velocity() <= 0.0f)
+            {
+                return;
+            }
+
+            if (!body_physics.is_collision(jumping_physics, jumping_position, body_position))
+            {
+                return;
+            }
+
+            if (take_damage_entity == give_damage_entity)
+            {
+                return;
+            }
+
+            if (jumping_position.y_center > body_position.y_center - (body_physics.get_height() / 2.0f))
+            {
+                return;
+            }
+
+            jumping_physics.set_y_velocity(-0.15f);
+
+            const JumpOnTopDamage_t damage = give_damage.get_damage();
+            take_damage.notify(damage);
+            remove_hitpoints(hitpoints, damage);
+        });
+    };
+
+    registry.view<GiveJumpOnTopDamageComponent, PhysicsComponent, PositionComponent>().each(give_jump_on_top_damage);
 }

--- a/src/game-loop/src/system/RenderingSystem.cpp
+++ b/src/game-loop/src/system/RenderingSystem.cpp
@@ -18,6 +18,7 @@ void RenderingSystem::update(std::uint32_t delta_time_ms)
     sort(); // FIXME: Sorting components every frame!
 
     // FIXME: Pointers to meshes may become invalidated after entity pool resize. Same as BombSpawner.cpp:31.
+    //        Temporary workaround at GameLoopStartedState.cpp:35 - reserving quads/meshes up-front.
     auto meshes = registry.view<MeshComponent>();
     meshes.each([this](MeshComponent &mesh)
     {

--- a/src/patterns/interface/patterns/Subject.hpp
+++ b/src/patterns/interface/patterns/Subject.hpp
@@ -6,6 +6,8 @@
 #include <vector>
 #include <algorithm>
 
+// TODO: BlankEvent_t?
+
 template<class EventType>
 class Subject
 {

--- a/src/patterns/interface/patterns/Subject.hpp
+++ b/src/patterns/interface/patterns/Subject.hpp
@@ -6,8 +6,6 @@
 #include <vector>
 #include <algorithm>
 
-// TODO: BlankEvent_t?
-
 template<class EventType>
 class Subject
 {


### PR DESCRIPTION
![damage_system](https://user-images.githubusercontent.com/13459304/108544231-796a8280-72e6-11eb-97da-32db5702e787.gif)

### Motivation
To enable killing NPC's in all methods possible in the original game.

### New components and example of application:

* `HitpointComponent` - i.e spider, bat, snake, caveman, skeleton, jar 
* `GiveMeleeDamageComponent` - i.e whip
* `GiveProjectileDamageComponent` - i.e rock, skull, jar, arrow
* `GiveJumpOnTopDamage` - i.e main dude
* `TakeFallDamageComponent` - i.e skeleton, in the future - also main dude
* `TakeProjectileDamageComponent` - i.e spider, bat, snake, jar
* `TakeMeleeDamageComponent` - i.e spider, bat, snake, jar
* `TakeTileCollisionDamageComponent` - i.e bullet, jar, skull
* `TakeJumpOnTopDamage` - i.e spider, bat, snake, skeleton

Additionally, to track killed NPC's and display them in the level summary screen:

* NpcTypeComponent - i.e spider, bat, snake, skeleton

Notifying NPC's of damage taken is done by the subject-observer pattern - `HitpointComponent` is a `Subject<DeathEvent>` and all the `Take_XXX_Damage` components issue individual events to differentiate type of damage, i.e `TakeFallDamageComponent` is a `Subject<FallDamage_t>`.

### Technical debt

* A utility for creating parametrized number and type of particles with random velocity is needed. Places for application - `SpiderDeathObserver`, `SnakeDeathObserver`, `BatDeathObserver`, `CavemanDeathObserver`.
* `Subject` should hold a collection of weak pointers instead of raw pointers to make sure only valid pointers are de-referenced.
* Entities should be marked for deletion and removed after they pass the system, instead of doing it mid-function
* `LevelSummaryTracker` should be replaced with an ECS equivalent - `LevelSummarySystem` and subsequent components.

### Inconsistencies with original game

* Caveman's body should stay upon killing it (with an `ItemComponent` added)