### PR TITLE
Permanent item inventory

### DIFF
--- a/src/game-loop/CMakeLists.txt
+++ b/src/game-loop/CMakeLists.txt
@@ -264,6 +264,7 @@ add_library(GameLoop STATIC
         include/other/NpcType.hpp
         include/other/ParticleGenerator.hpp
         src/other/ParticleGenerator.cpp
+        interface/other/ItemType.hpp
 )
 
 target_include_directories(GameLoop

--- a/src/game-loop/include/components/generic/ItemCarrierComponent.hpp
+++ b/src/game-loop/include/components/generic/ItemCarrierComponent.hpp
@@ -4,10 +4,12 @@
 #include "components/generic/PhysicsComponent.hpp"
 #include "components/generic/PositionComponent.hpp"
 #include "components/generic/HorizontalOrientationComponent.hpp"
+#include "other/ItemType.hpp"
 #include "EntityRegistry.hpp"
 #include "entt/entt.hpp"
 
 #include <vector>
+#include <algorithm>
 
 class ItemCarrierComponent
 {
@@ -27,6 +29,8 @@ public:
 
     void update_carried_items_positions(PositionComponent& position);
     void update_carried_items_orientation(HorizontalOrientationComponent& orientation);
+
+    std::vector<ItemType> get_items() const;
 
 private:
 

--- a/src/game-loop/include/components/generic/ItemComponent.hpp
+++ b/src/game-loop/include/components/generic/ItemComponent.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
+#include "other/ItemType.hpp"
 #include "entt/entt.hpp"
 #include "Point2D.hpp"
 
-enum class ItemType
+enum class ItemApplication
 {
     THROWABLE,
     ACTIVABLE,
@@ -26,8 +27,9 @@ class ItemComponent
 public:
 
     ItemComponent() = default;
-    ItemComponent(ItemType type, ItemSlot slot)
+    ItemComponent(ItemType type, ItemApplication application, ItemSlot slot)
         : _type(type)
+        , _application(application)
         , _slot(slot)
     {}
 
@@ -43,15 +45,17 @@ public:
     void set_weight(float weight_kilos) { _weight_kilos = weight_kilos; };
     float get_weight_kilos() const { return _weight_kilos; };
 
-    ItemSlot get_slot() const { return _slot; }
     ItemType get_type() const { return _type; }
+    ItemSlot get_slot() const { return _slot; }
+    ItemApplication get_application() const { return _application; }
 
     void set_slot(ItemSlot slot) { _slot = slot; }
-    void set_type(ItemType type) { _type = type; }
+    void set_type(ItemApplication application) { _application = application; }
 
 private:
 
     ItemType _type{};
+    ItemApplication _application{};
     ItemSlot _slot{};
     entt::entity _carrier = entt::null;
     Point2D _carrying_offset = {0.0f, 0.0f};

--- a/src/game-loop/include/populator/Populator.hpp
+++ b/src/game-loop/include/populator/Populator.hpp
@@ -13,4 +13,5 @@ namespace populator
 {
     void generate_loot(std::shared_ptr<LevelSummaryTracker>&);
     void generate_npc(std::shared_ptr<LevelSummaryTracker>&);
+    void generate_inventory_items(entt::entity main_dude);
 }

--- a/src/game-loop/interface/other/Inventory.hpp
+++ b/src/game-loop/interface/other/Inventory.hpp
@@ -3,8 +3,10 @@
 #include "patterns/Singleton.hpp"
 #include "patterns/Subject.hpp"
 #include "other/InventoryEvent.hpp"
+#include "other/ItemType.hpp"
 
 #include <cstdint>
+#include <vector>
 
 class Inventory : public Singleton<Inventory>, public Subject<InventoryEvent>
 {
@@ -23,9 +25,15 @@ public:
     void add_dollars(uint16_t amount);
     void remove_hearts(uint16_t amount);
 
+    const std::vector<ItemType>& get_items() const;
+    void set_items(const std::vector<ItemType>& items);
+    void clear_items();
+
 private:
 
     Inventory();
+
+    std::vector<ItemType> _items;
 
     int16_t _hearts;
     int16_t _ropes;

--- a/src/game-loop/interface/other/ItemType.hpp
+++ b/src/game-loop/interface/other/ItemType.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+enum class ItemType
+{
+    ARROW,
+    BOMB,
+    CAPE,
+    CHEST,
+    CRATE,
+    JAR,
+    JETPACK,
+    PISTOL,
+    ROCK,
+    ROPE,
+    SHOTGUN,
+    SKULL,
+    WHIP,
+    BOMB_SPAWNER,
+    ROPE_SPAWNER,
+};

--- a/src/game-loop/src/components/generic/ItemCarrierComponent.cpp
+++ b/src/game-loop/src/components/generic/ItemCarrierComponent.cpp
@@ -204,3 +204,31 @@ bool ItemCarrierComponent::is_carried(entt::entity item_entity) const
            item_entity == _slots.active_item ||
            std::find(_slots.other.begin(), _slots.other.end(), item_entity) != _slots.other.end();
 }
+
+std::vector<ItemType> ItemCarrierComponent::get_items() const
+{
+    auto& registry = EntityRegistry::instance().get_registry();
+
+    std::vector<ItemType> out;
+    std::vector<entt::entity> item_entities =
+            {
+                    _slots.active_item,
+                    _slots.passive_item_feet,
+                    _slots.passive_item_hands,
+                    _slots.passive_item_back
+            };
+    std::copy(_slots.other.begin(), _slots.other.end(), std::back_inserter(item_entities));
+
+    for (const auto& entity : item_entities)
+    {
+        if (entity == entt::null)
+        {
+            continue;
+        }
+
+        auto &item_component = registry.get<ItemComponent>(entity);
+        out.push_back(item_component.get_type());
+    }
+
+    return out;
+}

--- a/src/game-loop/src/components/generic/ItemCarrierComponent.cpp
+++ b/src/game-loop/src/components/generic/ItemCarrierComponent.cpp
@@ -211,12 +211,12 @@ std::vector<ItemType> ItemCarrierComponent::get_items() const
 
     std::vector<ItemType> out;
     std::vector<entt::entity> item_entities =
-            {
-                    _slots.active_item,
-                    _slots.passive_item_feet,
-                    _slots.passive_item_hands,
-                    _slots.passive_item_back
-            };
+    {
+            _slots.active_item,
+            _slots.passive_item_feet,
+            _slots.passive_item_hands,
+            _slots.passive_item_back
+    };
     std::copy(_slots.other.begin(), _slots.other.end(), std::back_inserter(item_entities));
 
     for (const auto& entity : item_entities)

--- a/src/game-loop/src/game-loop/GameLoopLevelSummaryState.cpp
+++ b/src/game-loop/src/game-loop/GameLoopLevelSummaryState.cpp
@@ -1,3 +1,4 @@
+#include "populator/Populator.hpp"
 #include "prefabs/main-dude/MainDude.hpp"
 #include "prefabs/ui/LevelSummaryOverlay.hpp"
 
@@ -11,6 +12,7 @@
 #include "system/ScriptingSystem.hpp"
 #include "system/PhysicsSystem.hpp"
 #include "system/AnimationSystem.hpp"
+#include "system/ItemSystem.hpp"
 
 #include "EntityRegistry.hpp"
 #include "logger/log.h"
@@ -27,11 +29,13 @@ GameLoopBaseState *GameLoopLevelSummaryState::update(GameLoop& game_loop, uint32
     auto& scripting_system = game_loop._scripting_system;
     auto& physics_system = game_loop._physics_system;
     auto& animation_system = game_loop._animation_system;
+    auto& item_system = game_loop._item_system;
 
     rendering_system->update(delta_time_ms);
     scripting_system->update(delta_time_ms);
     physics_system->update(delta_time_ms);
     animation_system->update(delta_time_ms);
+    item_system->update(delta_time_ms);
 
     auto& dude = registry.get<MainDudeComponent>(_main_dude);
 
@@ -76,6 +80,8 @@ void GameLoopLevelSummaryState::enter(GameLoop& game_loop)
     _main_dude = prefabs::MainDude::create(pos_x, pos_y);
     auto& dude = registry.get<MainDudeComponent>(_main_dude);
     dude.enter_level_summary_state();
+
+    populator::generate_inventory_items(_main_dude);
 
     rendering_system->sort();
 }

--- a/src/game-loop/src/game-loop/GameLoopPlayingState.cpp
+++ b/src/game-loop/src/game-loop/GameLoopPlayingState.cpp
@@ -13,6 +13,7 @@
 #include "components/specialized/DeathOverlayComponent.hpp"
 #include "components/specialized/LevelSummaryTracker.hpp"
 #include "components/specialized/MainDudeComponent.hpp"
+#include "components/generic/ItemCarrierComponent.hpp"
 
 #include "system/RenderingSystem.hpp"
 #include "system/DamageSystem.hpp"
@@ -148,6 +149,8 @@ void GameLoopPlayingState::enter(GameLoop& game_loop)
 
     populator::generate_loot(game_loop._level_summary_tracker);
     populator::generate_npc(game_loop._level_summary_tracker);
+    populator::generate_inventory_items(_main_dude);
+
     game_loop._level_summary_tracker->entered_new_level();
 }
 
@@ -157,8 +160,13 @@ void GameLoopPlayingState::exit(GameLoop& game_loop)
     Audio::instance().stop();
 
     auto& dude = registry.get<MainDudeComponent>(_main_dude);
-    dude.remove_observer(this);
+    auto& dude_item_carrier_component = registry.get<ItemCarrierComponent>(_main_dude);
 
+    // Save collected item types in inventory which is persistent between the levels:
+    auto& inventory = Inventory::instance();
+    inventory.set_items(dude_item_carrier_component.get_items());
+
+    dude.remove_observer(this);
     registry.clear();
 }
 

--- a/src/game-loop/src/game-loop/GameLoopScoresState.cpp
+++ b/src/game-loop/src/game-loop/GameLoopScoresState.cpp
@@ -17,6 +17,7 @@
 #include "system/AnimationSystem.hpp"
 #include "system/InputSystem.hpp"
 
+#include "populator/Populator.hpp"
 #include "logger/log.h"
 #include "ModelViewCamera.hpp"
 #include "ScreenSpaceCamera.hpp"
@@ -85,6 +86,9 @@ void GameLoopScoresState::enter(GameLoop& game_loop)
     model_view_camera.set_x_not_rounded(game_loop._viewport->get_width_world_units() / 4.0f);
     model_view_camera.set_y_not_rounded(game_loop._viewport->get_height_world_units() / 4.0f);
     model_view_camera.update_gl_modelview_matrix();
+
+    auto& inventory = Inventory::instance();
+    inventory.clear_items();
 
     MapTile* entrance = nullptr;
     Level::instance().get_tile_batch().get_first_tile_of_given_type(MapTileType::EXIT, entrance);

--- a/src/game-loop/src/other/Inventory.cpp
+++ b/src/game-loop/src/other/Inventory.cpp
@@ -13,6 +13,7 @@ void Inventory::set_starting_inventory()
     _bombs = 4;
     _ropes = 4;
     _dollars = 0;
+    _items.clear();
 }
 
 void Inventory::remove_hearts(uint16_t amount)
@@ -25,4 +26,19 @@ void Inventory::add_dollars(uint16_t amount)
 {
     _dollars += amount;
     notify(InventoryEvent::DOLLARS_COUNT_CHANGED);
+}
+
+const std::vector<ItemType> &Inventory::get_items() const
+{
+    return _items;
+}
+
+void Inventory::set_items(const std::vector<ItemType> &items)
+{
+    _items = items;
+}
+
+void Inventory::clear_items()
+{
+    _items.clear();
 }

--- a/src/game-loop/src/populator/Populator.cpp
+++ b/src/game-loop/src/populator/Populator.cpp
@@ -3,6 +3,8 @@
 
 #include "components/specialized/LevelSummaryTracker.hpp"
 #include "components/generic/CollectibleComponent.hpp"
+#include "components/generic/ItemCarrierComponent.hpp"
+#include "components/generic/PositionComponent.hpp"
 
 #include "prefabs/collectibles/SingleGoldBar.hpp"
 #include "prefabs/collectibles/TripleGoldBar.hpp"
@@ -11,6 +13,18 @@
 #include "prefabs/items/Jar.hpp"
 #include "prefabs/items/Crate.hpp"
 #include "prefabs/items/Chest.hpp"
+#include "prefabs/items/Arrow.hpp"
+#include "prefabs/items/Rope.hpp"
+#include "prefabs/items/Pistol.hpp"
+#include "prefabs/items/Bomb.hpp"
+#include "prefabs/items/Cape.hpp"
+#include "prefabs/items/Shotgun.hpp"
+#include "prefabs/items/Skull.hpp"
+#include "prefabs/items/Rock.hpp"
+#include "prefabs/items/Jar.hpp"
+#include "prefabs/items/Crate.hpp"
+#include "prefabs/items/Chest.hpp"
+#include "prefabs/items/Jetpack.hpp"
 #include "prefabs/traps/Spikes.hpp"
 #include "prefabs/traps/ArrowTrap.hpp"
 #include "prefabs/npc/Snake.hpp"
@@ -22,6 +36,42 @@
 
 #include "EntityRegistry.hpp"
 #include "Level.hpp"
+
+void populator::generate_inventory_items(entt::entity main_dude)
+{
+    auto& registry = EntityRegistry::instance().get_registry();
+
+    auto& inventory = Inventory::instance();
+    auto& dude_item_carrier_component = registry.get<ItemCarrierComponent>(main_dude);
+
+    for (const auto& item_type : inventory.get_items())
+    {
+        entt::entity item = entt::null;
+
+        switch (item_type)
+        {
+            case ItemType::ARROW: item = prefabs::Arrow::create(); break;
+            case ItemType::BOMB: item = prefabs::Bomb::create(); break;
+            case ItemType::CAPE: item = prefabs::Cape::create(); break;
+            case ItemType::CHEST: item = prefabs::Chest::create(); break;
+            case ItemType::CRATE: item = prefabs::Crate::create(); break;
+            case ItemType::JAR: item = prefabs::Jar::create(); break;
+            case ItemType::JETPACK: item = prefabs::Jetpack::create(); break;
+            case ItemType::PISTOL: item = prefabs::Pistol::create(); break;
+            case ItemType::ROCK: item = prefabs::Rock::create(); break;
+            case ItemType::ROPE: item = prefabs::Rope::create(); break;
+            case ItemType::SHOTGUN: item = prefabs::Shotgun::create(); break;
+            case ItemType::SKULL: item = prefabs::Skull::create(); break;
+            // These items are added by default when creating main dude instance:
+            case ItemType::WHIP:
+            case ItemType::BOMB_SPAWNER:
+            case ItemType::ROPE_SPAWNER:
+            default: continue;
+        }
+
+        dude_item_carrier_component.pick_up_item(item, main_dude);
+    }
+}
 
 void populator::generate_npc(std::shared_ptr<LevelSummaryTracker>& tracker)
 {

--- a/src/game-loop/src/prefabs/items/Arrow.cpp
+++ b/src/game-loop/src/prefabs/items/Arrow.cpp
@@ -114,7 +114,7 @@ entt::entity prefabs::Arrow::create(float pos_x_center, float pos_y_center)
     physics.set_friction(0.02f);
     physics.set_bounciness(0.25f);
 
-    ItemComponent item(ItemType::THROWABLE, ItemSlot::ACTIVE);
+    ItemComponent item(ItemType::ARROW, ItemApplication::THROWABLE, ItemSlot::ACTIVE);
     item.set_weight(1.0f);
 
     auto arrow_script = std::make_shared<ArrowScript>(entity);

--- a/src/game-loop/src/prefabs/items/Bomb.cpp
+++ b/src/game-loop/src/prefabs/items/Bomb.cpp
@@ -41,7 +41,7 @@ namespace
 
             if (_armed)
             {
-                item.set_type(ItemType::THROWABLE);
+                item.set_type(ItemApplication::THROWABLE);
                 _armed_timer_ms += delta_time_ms;
                 if (_armed_timer_ms >= explosion_ms)
                 {
@@ -166,7 +166,7 @@ entt::entity prefabs::Bomb::create(float pos_x_center, float pos_y_center)
     physics.set_friction(0.01f);
     physics.set_bounciness(0.35f);
 
-    ItemComponent item(ItemType::ACTIVABLE, ItemSlot::ACTIVE);
+    ItemComponent item(ItemType::BOMB, ItemApplication::ACTIVABLE, ItemSlot::ACTIVE);
     item.set_weight(2);
     item.set_carrying_offset({0.1f, 0.0f});
 

--- a/src/game-loop/src/prefabs/items/BombSpawner.cpp
+++ b/src/game-loop/src/prefabs/items/BombSpawner.cpp
@@ -48,7 +48,7 @@ entt::entity prefabs::BombSpawner::create()
     ActivableComponent activable;
     activable.activate_combination = { InputEvent::OUT_BOMB_PRESSED };
 
-    registry.emplace<ItemComponent>(entity, ItemType::ACTIVABLE, ItemSlot::OTHER);
+    registry.emplace<ItemComponent>(entity, ItemType::BOMB_SPAWNER, ItemApplication::ACTIVABLE, ItemSlot::OTHER);
     registry.emplace<ScriptingComponent>(entity, std::make_shared<BombSpawnerScript>());
     registry.emplace<ActivableComponent>(entity, activable);
 

--- a/src/game-loop/src/prefabs/items/Cape.cpp
+++ b/src/game-loop/src/prefabs/items/Cape.cpp
@@ -103,7 +103,7 @@ entt::entity prefabs::Cape::create(float pos_x_center, float pos_y_center)
     ActivableComponent activable;
     activable.activate_combination = { InputEvent::JUMPING_PRESSED };
 
-    ItemComponent item(ItemType::ACTIVABLE, ItemSlot::BACK);
+    ItemComponent item(ItemType::CAPE, ItemApplication::ACTIVABLE, ItemSlot::BACK);
     item.set_carrying_offset({-0.4f, 0.0f});
 
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);

--- a/src/game-loop/src/prefabs/items/Chest.cpp
+++ b/src/game-loop/src/prefabs/items/Chest.cpp
@@ -85,7 +85,7 @@ entt::entity prefabs::Chest::create(float pos_x_center, float pos_y_center)
     physics.set_friction(0.02f);
     physics.set_bounciness(0.25f);
 
-    ItemComponent item(ItemType::OPENABLE, ItemSlot::ACTIVE);
+    ItemComponent item(ItemType::CHEST, ItemApplication::OPENABLE, ItemSlot::ACTIVE);
     item.set_weight(5);
     item.set_carrying_offset({0.0f, -0.3f});
 

--- a/src/game-loop/src/prefabs/items/Crate.cpp
+++ b/src/game-loop/src/prefabs/items/Crate.cpp
@@ -136,7 +136,7 @@ entt::entity prefabs::Crate::create(float pos_x_center, float pos_y_center)
     physics.set_friction(0.02f);
     physics.set_bounciness(0.25f);
 
-    ItemComponent item(ItemType::OPENABLE, ItemSlot::ACTIVE);
+    ItemComponent item(ItemType::CRATE, ItemApplication::OPENABLE, ItemSlot::ACTIVE);
     item.set_weight(5);
     item.set_carrying_offset({0.0f, -0.3f});
 

--- a/src/game-loop/src/prefabs/items/Jar.cpp
+++ b/src/game-loop/src/prefabs/items/Jar.cpp
@@ -137,7 +137,7 @@ entt::entity prefabs::Jar::create(float pos_x_center, float pos_y_center)
     PhysicsComponent physics(width, height);
     physics.set_friction(0.02f);
 
-    ItemComponent item(ItemType::THROWABLE, ItemSlot::ACTIVE);
+    ItemComponent item(ItemType::JAR, ItemApplication::THROWABLE, ItemSlot::ACTIVE);
     item.set_weight(2);
     item.set_carrying_offset({0.0f, -1.0f/8.0f});
 

--- a/src/game-loop/src/prefabs/items/Jetpack.cpp
+++ b/src/game-loop/src/prefabs/items/Jetpack.cpp
@@ -104,7 +104,7 @@ entt::entity prefabs::Jetpack::create(float pos_x_center, float pos_y_center)
     ActivableComponent activable;
     activable.activate_combination = { InputEvent::JUMPING_PRESSED };
 
-    ItemComponent item(ItemType::ACTIVABLE, ItemSlot::BACK);
+    ItemComponent item(ItemType::JETPACK, ItemApplication::ACTIVABLE, ItemSlot::BACK);
     item.set_carrying_offset({-0.4f, -0.2f});
 
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);

--- a/src/game-loop/src/prefabs/items/Pistol.cpp
+++ b/src/game-loop/src/prefabs/items/Pistol.cpp
@@ -87,7 +87,7 @@ entt::entity prefabs::Pistol::create(float pos_x_center, float pos_y_center)
     ActivableComponent activable;
     activable.activate_combination = { InputEvent::THROWING_PRESSED };
 
-    ItemComponent item(ItemType::ACTIVABLE, ItemSlot::ACTIVE);
+    ItemComponent item(ItemType::PISTOL, ItemApplication::ACTIVABLE, ItemSlot::ACTIVE);
     item.set_carrying_offset({0.1f, 0.1f});
 
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);

--- a/src/game-loop/src/prefabs/items/Rock.cpp
+++ b/src/game-loop/src/prefabs/items/Rock.cpp
@@ -33,7 +33,7 @@ entt::entity prefabs::Rock::create(float pos_x_center, float pos_y_center)
     physics.set_friction(0.02f);
     physics.set_bounciness(0.4f);
 
-    ItemComponent item(ItemType::THROWABLE, ItemSlot::ACTIVE);
+    ItemComponent item(ItemType::ROCK, ItemApplication::THROWABLE, ItemSlot::ACTIVE);
     item.set_weight(2);
 
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);

--- a/src/game-loop/src/prefabs/items/Rope.cpp
+++ b/src/game-loop/src/prefabs/items/Rope.cpp
@@ -121,7 +121,7 @@ entt::entity prefabs::Rope::create(float pos_x_center, float pos_y_center)
     QuadComponent quad(TextureType::COLLECTIBLES, width, height);
     quad.frame_changed(CollectiblesSpritesheetFrames::ROPE_ITEM);
 
-    ItemComponent item(ItemType::ACTIVABLE, ItemSlot::ACTIVE);
+    ItemComponent item(ItemType::ROPE, ItemApplication::ACTIVABLE, ItemSlot::ACTIVE);
     item.set_weight(2);
     item.set_carrying_offset({0.1f, 0.0f});
 

--- a/src/game-loop/src/prefabs/items/RopeSpawner.cpp
+++ b/src/game-loop/src/prefabs/items/RopeSpawner.cpp
@@ -48,7 +48,7 @@ entt::entity prefabs::RopeSpawner::create()
     ActivableComponent activable;
     activable.activate_combination = { InputEvent::OUT_ROPE_PRESSED };
 
-    registry.emplace<ItemComponent>(entity, ItemType::ACTIVABLE, ItemSlot::OTHER);
+    registry.emplace<ItemComponent>(entity, ItemType::ROPE_SPAWNER, ItemApplication::ACTIVABLE, ItemSlot::OTHER);
     registry.emplace<ScriptingComponent>(entity, std::make_shared<RopeSpawnerScript>());
     registry.emplace<ActivableComponent>(entity, activable);
 

--- a/src/game-loop/src/prefabs/items/Shotgun.cpp
+++ b/src/game-loop/src/prefabs/items/Shotgun.cpp
@@ -105,7 +105,7 @@ entt::entity prefabs::Shotgun::create(float pos_x_center, float pos_y_center)
     ActivableComponent activable;
     activable.activate_combination = { InputEvent::THROWING_PRESSED };
 
-    ItemComponent item(ItemType::ACTIVABLE, ItemSlot::ACTIVE);
+    ItemComponent item(ItemType::SHOTGUN, ItemApplication::ACTIVABLE, ItemSlot::ACTIVE);
     item.set_carrying_offset({0.1f, 0.1f});
 
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);

--- a/src/game-loop/src/prefabs/items/Skull.cpp
+++ b/src/game-loop/src/prefabs/items/Skull.cpp
@@ -94,7 +94,7 @@ entt::entity prefabs::Skull::create(float pos_x_center, float pos_y_center)
     PhysicsComponent physics(width, height);
     physics.set_friction(0.02f);
 
-    ItemComponent item(ItemType::THROWABLE, ItemSlot::ACTIVE);
+    ItemComponent item(ItemType::SKULL, ItemApplication::THROWABLE, ItemSlot::ACTIVE);
     item.set_weight(2);
     item.set_carrying_offset({0.0f, -1.0f/8.0f});
 

--- a/src/game-loop/src/prefabs/items/Whip.cpp
+++ b/src/game-loop/src/prefabs/items/Whip.cpp
@@ -141,7 +141,7 @@ entt::entity prefabs::Whip::create(float pos_x_center, float pos_y_center)
 
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<PhysicsComponent>(entity, width, height);
-    registry.emplace<ItemComponent>(entity, ItemType::ACTIVABLE, ItemSlot::OTHER);
+    registry.emplace<ItemComponent>(entity, ItemType::WHIP, ItemApplication::ACTIVABLE, ItemSlot::OTHER);
     registry.emplace<ScriptingComponent>(entity, std::make_shared<WhipScript>());
     registry.emplace<HorizontalOrientationComponent>(entity);
     registry.emplace<ActivableComponent>(entity, activable);

--- a/src/game-loop/src/system/InputSystem.cpp
+++ b/src/game-loop/src/system/InputSystem.cpp
@@ -178,7 +178,7 @@ void InputSystem::update_items_pick_up_put_down()
         {
             auto& item = carrier.get_active_item();
 
-            if (!open_intent && throw_intent && item.get_type() != ItemType::ACTIVABLE)
+            if (!open_intent && throw_intent && item.get_application() != ItemApplication::ACTIVABLE)
             {
                 carrier.throw_active_item(carrier_orientation, carrier_physics);
                 consume(InputEvent::THROWING_PRESSED);
@@ -264,7 +264,7 @@ void InputSystem::update_items_open()
                 if (registry.has<ItemComponent>(openable_entity))
                 {
                     auto& item = registry.get<ItemComponent>(openable_entity);
-                    item.set_type(ItemType::THROWABLE);
+                    item.set_type(ItemApplication::THROWABLE);
                 }
 
                 return;


### PR DESCRIPTION
Main dude instance is created and disposed in each level - thus for saving permanent state, `Inventory` singleton is utilized (so far only for hearts/bombs/ropes/dollars).

I extended `Inventory` singleton to also save carried item types upon each `GameLoopPlayingState` exit and re-populate instances of them on each entry.

Inventory is cleaned upon entering `GameLoopScoresState`.