### PR TITLE
Re-implementing climbing with both ladders/ropes

### DIFF
--- a/src/game-loop/CMakeLists.txt
+++ b/src/game-loop/CMakeLists.txt
@@ -265,6 +265,7 @@ add_library(GameLoop STATIC
         include/other/ParticleGenerator.hpp
         src/other/ParticleGenerator.cpp
         interface/other/ItemType.hpp
+        include/components/generic/ClimbingComponent.hpp
 )
 
 target_include_directories(GameLoop

--- a/src/game-loop/CMakeLists.txt
+++ b/src/game-loop/CMakeLists.txt
@@ -23,7 +23,7 @@ add_library(GameLoop STATIC
         src/main-dude/MainDudeComponent.cpp
         src/main-dude/states/MainDudeStandingState.cpp
         src/main-dude/states/MainDudeCliffHangingState.cpp
-        src/main-dude/states/MainDudeClimbingLadderState.cpp
+        src/main-dude/states/MainDudeClimbingState.cpp
         src/main-dude/states/MainDudeLevelSummaryState.cpp
         src/main-dude/states/MainDudeExitingState.cpp
         src/main-dude/states/MainDudeThrowingState.cpp
@@ -38,7 +38,7 @@ add_library(GameLoop STATIC
         src/main-dude/states/MainDudeDeadState.cpp
         src/main-dude/states/MainDudeStunnedState.cpp
         include/main-dude/states/MainDudeBaseState.hpp
-        include/main-dude/states/MainDudeClimbingLadderState.hpp
+        include/main-dude/states/MainDudeClimbingState.hpp
         include/main-dude/states/MainDudeLevelSummaryState.hpp
         include/main-dude/states/MainDudeRunningState.hpp
         include/main-dude/states/MainDudeStandingState.hpp

--- a/src/game-loop/CMakeLists.txt
+++ b/src/game-loop/CMakeLists.txt
@@ -85,6 +85,7 @@ add_library(GameLoop STATIC
         include/components/generic/MeshComponent.hpp
         include/components/generic/ActivableComponent.hpp
         include/components/generic/NpcTypeComponent.hpp
+        include/components/generic/ClimbingComponent.hpp
         include/components/specialized/MainDudeComponent.hpp
         include/components/specialized/LevelSummaryTracker.hpp
         include/components/specialized/HudOverlayComponent.hpp
@@ -256,16 +257,15 @@ add_library(GameLoop STATIC
         include/populator/Populator.hpp
         include/populator/Spawner.hpp
 
+        src/other/ParticleGenerator.cpp
         src/other/Inventory.cpp
         interface/other/PhysicsComponentType.hpp
         interface/other/Inventory.hpp
         interface/other/InventoryEvent.hpp
+        interface/other/ItemType.hpp
         include/other/LootCollectedEvent.hpp
         include/other/NpcType.hpp
         include/other/ParticleGenerator.hpp
-        src/other/ParticleGenerator.cpp
-        interface/other/ItemType.hpp
-        include/components/generic/ClimbingComponent.hpp
 )
 
 target_include_directories(GameLoop

--- a/src/game-loop/include/components/generic/ClimbingComponent.hpp
+++ b/src/game-loop/include/components/generic/ClimbingComponent.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "patterns/Subject.hpp"
+
+enum class ClimbingEventType
+{
+    STARTED_CLIMBING_LADDER,
+    STARTED_CLIMBING_ROPE,
+};
+
+struct ClimbingEvent
+{
+    ClimbingEventType event_type;
+};
+
+struct ClimbingComponent : Subject<ClimbingEvent>
+{
+};

--- a/src/game-loop/include/components/specialized/MainDudeComponent.hpp
+++ b/src/game-loop/include/components/specialized/MainDudeComponent.hpp
@@ -26,15 +26,26 @@
 #include "main-dude/states/MainDudeStunnedState.hpp"
 #include "main-dude/MainDudeEvent.hpp"
 
+#include "components/generic/PhysicsComponent.hpp"
+#include "components/generic/PositionComponent.hpp"
+#include "components/generic/QuadComponent.hpp"
+#include "components/generic/AnimationComponent.hpp"
+#include "components/generic/ClimbingComponent.hpp"
+
 #include <vector>
-#include <components/generic/PhysicsComponent.hpp>
-#include <components/generic/PositionComponent.hpp>
-#include <components/generic/QuadComponent.hpp>
-#include <components/generic/AnimationComponent.hpp>
+#include <memory>
 
 class MainDudeBaseState;
 class Input;
 class MapTile;
+
+struct MainDudeClimbingObserver : Observer<ClimbingEvent>
+{
+    explicit MainDudeClimbingObserver(entt::entity main_dude) : _main_dude(main_dude) {};
+
+    void on_notify(const ClimbingEvent* event) override;
+    const entt::entity _main_dude;
+};
 
 class MainDudeComponent : public Subject<MainDudeEvent>
 {
@@ -49,8 +60,14 @@ public:
     void enter_dead_state();
     void enter_standing_state();
     void enter_throwing_state();
+    void enter_climbing_state();
 
     bool entered_door() const { return _other.entered_door; }
+
+    MainDudeClimbingObserver* get_observer()
+    {
+        return _climbing_observer.get();
+    }
 
 private:
 
@@ -106,6 +123,8 @@ private:
     } _other;
 
     entt::entity _owner = entt::null;
+
+    std::shared_ptr<MainDudeClimbingObserver> _climbing_observer;
 
     static constexpr float DEFAULT_DELTA_X = 0.01f;
     static constexpr float DEFAULT_MAX_X_VELOCITY = 0.050f;

--- a/src/game-loop/include/components/specialized/MainDudeComponent.hpp
+++ b/src/game-loop/include/components/specialized/MainDudeComponent.hpp
@@ -9,7 +9,7 @@
 #include "MapTileType.hpp"
 
 #include "main-dude/states/MainDudeRunningState.hpp"
-#include "main-dude/states/MainDudeClimbingLadderState.hpp"
+#include "main-dude/states/MainDudeClimbingState.hpp"
 #include "main-dude/states/MainDudeExitingState.hpp"
 #include "main-dude/states/MainDudeStandingState.hpp"
 #include "main-dude/states/MainDudePushingState.hpp"
@@ -39,12 +39,15 @@ class MainDudeBaseState;
 class Input;
 class MapTile;
 
-struct MainDudeClimbingObserver : Observer<ClimbingEvent>
+class MainDudeClimbingObserver : Observer<ClimbingEvent>
 {
+public:
     explicit MainDudeClimbingObserver(entt::entity main_dude) : _main_dude(main_dude) {};
-
     void on_notify(const ClimbingEvent* event) override;
+    ClimbingEvent get_last_event() const { return _last_event; }
+private:
     const entt::entity _main_dude;
+    ClimbingEvent _last_event{};
 };
 
 class MainDudeComponent : public Subject<MainDudeEvent>
@@ -64,7 +67,7 @@ public:
 
     bool entered_door() const { return _other.entered_door; }
 
-    MainDudeClimbingObserver* get_observer()
+    MainDudeClimbingObserver* get_climbing_observer()
     {
         return _climbing_observer.get();
     }
@@ -89,7 +92,7 @@ private:
     friend class MainDudeThrowingState;
     friend class MainDudeExitingState;
     friend class MainDudeLevelSummaryState;
-    friend class MainDudeClimbingLadderState;
+    friend class MainDudeClimbingState;
     friend class MainDudeCliffHangingState;
     friend class MainDudeLookingUpState;
     friend class MainDudeRunningLookingUpState;
@@ -107,7 +110,7 @@ private:
         MainDudeJumpingState jumping;
         MainDudeThrowingState throwing;
         MainDudeExitingState exiting;
-        MainDudeClimbingLadderState climbing;
+        MainDudeClimbingState climbing;
         MainDudeCliffHangingState cliff_hanging;
         MainDudeLookingUpState looking_up;
         MainDudeRunningLookingUpState running_looking_up;

--- a/src/game-loop/include/main-dude/states/MainDudeClimbingState.hpp
+++ b/src/game-loop/include/main-dude/states/MainDudeClimbingState.hpp
@@ -2,7 +2,7 @@
 
 #include "main-dude/states/MainDudeBaseState.hpp"
 
-class MainDudeClimbingLadderState : public MainDudeBaseState
+class MainDudeClimbingState : public MainDudeBaseState
 {
 public:
 

--- a/src/game-loop/src/main-dude/MainDudeComponent.cpp
+++ b/src/game-loop/src/main-dude/MainDudeComponent.cpp
@@ -40,7 +40,7 @@ MainDudeComponent::MainDudeComponent(entt::entity owner) : _owner(owner)
 MainDudeComponent::MainDudeComponent(const MainDudeComponent& other) : _owner(other._owner)
 {
     _states.current = &_states.standing;
-    _climbing_observer = std::make_shared<MainDudeClimbingObserver>(other._owner);
+    _climbing_observer = other._climbing_observer;
 }
 
 void MainDudeComponent::update(uint32_t delta_time_ms)
@@ -170,7 +170,9 @@ void MainDudeClimbingObserver::on_notify(const ClimbingEvent *event)
     auto& registry = EntityRegistry::instance().get_registry();
     auto& main_dude_component = registry.get<MainDudeComponent>(_main_dude);
 
-    switch (event->event_type)
+    _last_event = *event;
+
+    switch (_last_event.event_type)
     {
         case ClimbingEventType::STARTED_CLIMBING_LADDER:
         case ClimbingEventType::STARTED_CLIMBING_ROPE:

--- a/src/game-loop/src/main-dude/states/MainDudeFallingState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeFallingState.cpp
@@ -79,16 +79,6 @@ MainDudeBaseState* MainDudeFallingState::update(MainDudeComponent& dude, uint32_
             position.set_position_on_tile(exit_tile);
             return &dude._states.exiting;
         }
-
-        const auto* ladder_tile = dude.is_overlaping_tile(MapTileType::LADDER, physics, position);
-        const auto* ladder_deck_tile = dude.is_overlaping_tile(MapTileType::LADDER_DECK, physics, position);
-
-        if (ladder_tile || ladder_deck_tile)
-        {
-            const auto* tile = ladder_tile ? ladder_tile : ladder_deck_tile;
-            position.x_center = tile->x + quad.get_quad_width() / 2;
-            return &dude._states.climbing;
-        }
     }
 
     if (physics.is_bottom_collision())

--- a/src/game-loop/src/main-dude/states/MainDudeJumpingState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeJumpingState.cpp
@@ -77,17 +77,6 @@ MainDudeBaseState* MainDudeJumpingState::update(MainDudeComponent& dude, uint32_
             position.set_position_on_tile(exit_tile);
             return &dude._states.exiting;
         }
-
-        const auto* ladder_tile = dude.is_overlaping_tile(MapTileType::LADDER, physics, position);
-        const auto* ladder_deck_tile = dude.is_overlaping_tile(MapTileType::LADDER_DECK, physics, position);
-
-        if (ladder_tile || ladder_deck_tile)
-        {
-            const auto* tile = ladder_tile ? ladder_tile : ladder_deck_tile;
-            position.x_center = tile->x + quad.get_quad_width() / 2;
-
-            return &dude._states.climbing;
-        }
     }
 
     if (physics.is_bottom_collision())

--- a/src/game-loop/src/main-dude/states/MainDudeRunningLookingUpState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeRunningLookingUpState.cpp
@@ -91,15 +91,6 @@ MainDudeBaseState *MainDudeRunningLookingUpState::update(MainDudeComponent& dude
             return &dude._states.exiting;
         }
 
-        const auto* ladder_tile = dude.is_overlaping_tile(MapTileType::LADDER, physics, position);
-        const auto* ladder_deck_tile = dude.is_overlaping_tile(MapTileType::LADDER_DECK, physics, position);
-
-        if (ladder_tile || ladder_deck_tile)
-        {
-            const auto* tile = ladder_tile ? ladder_tile : ladder_deck_tile;
-            position.x_center = tile->x + quad.get_quad_width() / 2;
-            return &dude._states.climbing;
-        }
         return this;
     }
     else

--- a/src/game-loop/src/main-dude/states/MainDudeRunningState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeRunningState.cpp
@@ -86,16 +86,6 @@ MainDudeBaseState *MainDudeRunningState::update(MainDudeComponent& dude, uint32_
             return &dude._states.exiting;
         }
 
-        const auto* ladder_tile = dude.is_overlaping_tile(MapTileType::LADDER, physics, position);
-        const auto* ladder_deck_tile = dude.is_overlaping_tile(MapTileType::LADDER_DECK, physics, position);
-
-        if (ladder_tile || ladder_deck_tile)
-        {
-            const auto* tile = ladder_tile ? ladder_tile : ladder_deck_tile;
-            position.x_center = tile->x + quad.get_quad_width() / 2;
-            return &dude._states.climbing;
-        }
-
         return &dude._states.running_looking_up;
     }
 

--- a/src/game-loop/src/main-dude/states/MainDudeStandingState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeStandingState.cpp
@@ -70,17 +70,6 @@ MainDudeBaseState *MainDudeStandingState::update(MainDudeComponent& dude, uint32
             return &dude._states.exiting;
         }
 
-        const auto* ladder_tile = dude.is_overlaping_tile(MapTileType::LADDER, physics, position);
-        const auto* ladder_deck_tile = dude.is_overlaping_tile(MapTileType::LADDER_DECK, physics, position);
-
-        if (ladder_tile || ladder_deck_tile)
-        {
-            const auto* tile = ladder_tile ? ladder_tile : ladder_deck_tile;
-            position.x_center = tile->x + quad.get_quad_width() / 2;
-
-            return &dude._states.climbing;
-        }
-
         return &dude._states.looking_up;
     }
 

--- a/src/game-loop/src/prefabs/items/RopeSpawner.cpp
+++ b/src/game-loop/src/prefabs/items/RopeSpawner.cpp
@@ -26,7 +26,10 @@ namespace
 
                 if (!item_carrier.has_active_item())
                 {
-                    auto rope = prefabs::Rope::create();
+                    auto item_carrier_entity = item.get_item_carrier_entity();
+                    auto item_carrier_position = registry.get<PositionComponent>(item_carrier_entity);
+
+                    auto rope = prefabs::Rope::create(item_carrier_position.x_center, item_carrier_position.y_center);
 
                     // References may become invalid after creating new components (pool resize) - refreshing:
                     item = registry.get<ItemComponent>(owner);

--- a/src/game-loop/src/prefabs/main-dude/MainDude.cpp
+++ b/src/game-loop/src/prefabs/main-dude/MainDude.cpp
@@ -55,13 +55,9 @@ namespace prefabs
         MainDudeComponent main_dude(entity);
         registry.emplace<MainDudeComponent>(entity, main_dude);
 
-        // FIXME: Rework MainDudeComponent to be simply scripting component; this is prone to component relocation:
-        {
-            auto& main_dude_component = registry.get<MainDudeComponent>(entity);
-            ClimbingComponent climbing;
-            climbing.add_observer(reinterpret_cast<Observer<ClimbingEvent> *>(main_dude_component.get_observer()));
-            registry.emplace<ClimbingComponent>(entity, climbing);
-        }
+        ClimbingComponent climbing;
+        climbing.add_observer(reinterpret_cast<Observer<ClimbingEvent> *>(main_dude.get_climbing_observer()));
+        registry.emplace<ClimbingComponent>(entity, climbing);
 
         {
             auto& carrier = registry.get<ItemCarrierComponent>(entity);

--- a/src/game-loop/src/prefabs/main-dude/MainDude.cpp
+++ b/src/game-loop/src/prefabs/main-dude/MainDude.cpp
@@ -5,6 +5,7 @@
 
 #include "components/damage/GiveJumpOnTopDamage.hpp"
 #include "components/generic/PositionComponent.hpp"
+#include "components/generic/ClimbingComponent.hpp"
 #include "components/generic/QuadComponent.hpp"
 #include "components/generic/AnimationComponent.hpp"
 #include "components/generic/HorizontalOrientationComponent.hpp"
@@ -53,6 +54,14 @@ namespace prefabs
         // Initialization order is important in this case - MainDudeComponent must be the last to create.
         MainDudeComponent main_dude(entity);
         registry.emplace<MainDudeComponent>(entity, main_dude);
+
+        // FIXME: Rework MainDudeComponent to be simply scripting component; this is prone to component relocation:
+        {
+            auto& main_dude_component = registry.get<MainDudeComponent>(entity);
+            ClimbingComponent climbing;
+            climbing.add_observer(reinterpret_cast<Observer<ClimbingEvent> *>(main_dude_component.get_observer()));
+            registry.emplace<ClimbingComponent>(entity, climbing);
+        }
 
         {
             auto& carrier = registry.get<ItemCarrierComponent>(entity);

--- a/src/level/interface/MapTile.hpp
+++ b/src/level/interface/MapTile.hpp
@@ -13,12 +13,20 @@ struct MapTile
     static constexpr float PHYSICAL_WIDTH = 1.0f;
     static constexpr float PHYSICAL_HEIGHT = 1.0f;
 
-    MapTile() : x(0), y(0), collidable(false), destroyable(false), map_tile_type(MapTileType::NOTHING) {}
+    MapTile()
+        : x(0)
+        , y(0)
+        , collidable(false)
+        , destroyable(false)
+        , climbable(false)
+        , map_tile_type(MapTileType::NOTHING)
+    {}
 
     int x; // in tiles
     int y; // in tiles
     bool collidable;
     bool destroyable;
+    bool climbable;
     MapTileType map_tile_type;
 
     // Sets tile's properties (i.e whether it is collidable or destroyable) to be of exact tile type.

--- a/src/level/src/MapTile.cpp
+++ b/src/level/src/MapTile.cpp
@@ -36,173 +36,203 @@ void MapTile::match_tile(MapTileType type)
         {
             collidable = false;
             destroyable = false;
+            climbable = false;
             break;
         }
         case MapTileType::EXIT:
         {
             collidable = false;
             destroyable = false;
+            climbable = false;
             break;
         }
         case MapTileType::CONSOLE_LEFT_BAR_TOP_ROUNDED:
         {
             collidable = false;
             destroyable = false;
+            climbable = false;
             break;
         }
         case MapTileType::CONSOLE_RIGHT_BAR_TOP_ROUNDED:
         {
             collidable = false;
             destroyable = false;
+            climbable = false;
             break;
         }
         case MapTileType::CONSOLE_LEFT_BAR_BOT_ROUNDED:
         {
             collidable = false;
             destroyable = false;
+            climbable = false;
             break;
         }
         case MapTileType::CONSOLE_RIGHT_BAR_BOT_ROUNDED:
         {
             collidable = false;
             destroyable = false;
+            climbable = false;
             break;
         }
         case MapTileType::CONSOLE_TOP_BAR:
         {
             collidable = false;
             destroyable = false;
+            climbable = false;
             break;
         }
         case MapTileType::CONSOLE_BOTTOM_BAR:
         {
             collidable = false;
             destroyable = false;
+            climbable = false;
             break;
         }
         case MapTileType::CONSOLE_LEFT_BAR:
         {
             collidable = false;
             destroyable = false;
+            climbable = false;
             break;
         }
         case MapTileType::CONSOLE_RIGHT_BAR:
         {
             collidable = false;
             destroyable = false;
+            climbable = false;
             break;
         }
         case MapTileType::CONSOLE_BLACK_BACKGROUND:
         {
             collidable = false;
             destroyable = false;
+            climbable = false;
             break;
         }
         case MapTileType::CAVE_SMOOTH:
         {
             collidable = true;
             destroyable = true;
+            climbable = false;
+            break;
         }
         case MapTileType::CAVE_REGULAR:
         {
             collidable = true;
             destroyable = true;
+            climbable = false;
             break;
         }
         case MapTileType::SCORES_STAR_DOOR:
         {
             collidable = false;
             destroyable = false;
+            climbable = false;
             break;
         }
         case MapTileType::SCORES_SUN_DOOR:
         {
             collidable = false;
             destroyable = false;
+            climbable = false;
             break;
         }
         case MapTileType::SCORES_MOON_DOOR:
         {
             collidable = false;
             destroyable = false;
+            climbable = false;
             break;
         }
         case MapTileType::SCORES_CHANGING_DOOR:
         {
             collidable = false;
             destroyable = false;
+            climbable = false;
             break;
         }
         case MapTileType::SHOP_SIGN_RARE:
         {
             collidable = true;
             destroyable = true;
+            climbable = false;
             break;
         }
         case MapTileType::SHOP_SIGN_WEAPON:
         {
             collidable = true;
             destroyable = true;
+            climbable = false;
             break;
         }
         case MapTileType::SHOP_SIGN_BOMBS:
         {
             collidable = true;
             destroyable = true;
+            climbable = false;
             break;
         }
         case MapTileType::SHOP_SIGN_CLOTHING:
         {
             collidable = true;
             destroyable = true;
+            climbable = false;
             break;
         }
         case MapTileType::SHOP_SIGN_CRAPS:
         {
             collidable = true;
             destroyable = true;
+            climbable = false;
             break;
         }
         case MapTileType::SHOP_SIGN_GENERAL:
         {
             collidable = true;
             destroyable = true;
+            climbable = false;
             break;
         }
         case MapTileType::SHOP_SIGN_KISSING:
         {
             collidable = true;
             destroyable = true;
+            climbable = false;
             break;
         }
         case MapTileType::NA:
         {
             collidable = false;
             destroyable = false;
+            climbable = false;
             break;
         }
         case MapTileType::SHOP_MUGSHOT_1:
         {
             collidable = false;
             destroyable = false;
+            climbable = false;
             break;
         }
         case MapTileType::SHOP_MUGSHOT_2:
         {
             collidable = false;
             destroyable = false;
+            climbable = false;
             break;
         }
         case MapTileType::SHOP_MUGSHOT_3:
         {
             collidable = false;
             destroyable = false;
+            climbable = false;
             break;
         }
         case MapTileType::SHOP_MUGSHOT_4:
         {
             collidable = false;
             destroyable = false;
+            climbable = false;
             break;
         }
         case MapTileType::CAVE_BG_1:
@@ -212,6 +242,7 @@ void MapTile::match_tile(MapTileType type)
         {
             collidable = false;
             destroyable = false;
+            climbable = false;
             break;
         }
     }

--- a/src/level/src/MapTile.cpp
+++ b/src/level/src/MapTile.cpp
@@ -22,12 +22,14 @@ void MapTile::match_tile(MapTileType type)
         {
             collidable = false;
             destroyable = false;
+            climbable = true;
             break;
         }
         case MapTileType::LADDER_DECK:
         {
             collidable = false;
             destroyable = false;
+            climbable = true;
             break;
         }
         case MapTileType::ENTRANCE:

--- a/src/rendering-types/interface/Point2D.hpp
+++ b/src/rendering-types/interface/Point2D.hpp
@@ -5,6 +5,9 @@ struct Point2D
     float x;
     float y;
 
+    Point2D(float x, float y) : x(x), y(y) {}
+    Point2D() = default;
+
     bool operator==(const Point2D& other) const
     {
         return this->x == other.x && this->y == other.y;


### PR DESCRIPTION
Climbing was removed in v0.4 due to rework to ECS - it didn't fit to the new system-based implementation and I couldn't place it into the release schedule as it was full already.

Changes:

* Climbing is handled in a generic way through `InputSystem` - entity must have a `ClimbingComponent` to climb
* `MapTile` now has a `climbable` property. It is set by default on ladder tiles and dynamically on tiles overlapping with rope.
* `MainDudeClimbingLadderState` is renamed to `MainDudeClimbingState` as it now handles both rope and ladder