### PR TITLE
Main dude killable by NPC's

### DIFF
--- a/src/game-loop/CMakeLists.txt
+++ b/src/game-loop/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(GameLoop STATIC
 
         # Main dude:
 
+        src/main-dude/MainDudeObservers.cpp
         src/main-dude/MainDudeComponent.cpp
         src/main-dude/states/MainDudeStandingState.cpp
         src/main-dude/states/MainDudeCliffHangingState.cpp
@@ -55,6 +56,7 @@ add_library(GameLoop STATIC
         include/main-dude/states/MainDudeDeadState.hpp
         include/main-dude/states/MainDudeStunnedState.hpp
         include/main-dude/MainDudeEvent.hpp
+        include/main-dude/MainDudeObservers.hpp
 
         # Components:
 
@@ -92,6 +94,8 @@ add_library(GameLoop STATIC
         include/components/specialized/PauseOverlayComponent.hpp
         include/components/specialized/DeathOverlayComponent.hpp
         include/components/specialized/LevelSummaryOverlayComponent.hpp
+        include/components/damage/TakeNpcTouchDamageComponent.hpp
+        include/components/damage/GiveNpcTouchDamageComponent.hpp
         include/components/damage/HitpointComponent.hpp
         include/components/damage/GiveMeleeDamageComponent.hpp
         include/components/damage/GiveProjectileDamageComponent.hpp

--- a/src/game-loop/CMakeLists.txt
+++ b/src/game-loop/CMakeLists.txt
@@ -88,6 +88,7 @@ add_library(GameLoop STATIC
         include/components/generic/ActivableComponent.hpp
         include/components/generic/NpcTypeComponent.hpp
         include/components/generic/ClimbingComponent.hpp
+        include/components/generic/BlinkingComponent.hpp
         include/components/specialized/MainDudeComponent.hpp
         include/components/specialized/LevelSummaryTracker.hpp
         include/components/specialized/HudOverlayComponent.hpp

--- a/src/game-loop/include/components/damage/GiveNpcTouchDamageComponent.hpp
+++ b/src/game-loop/include/components/damage/GiveNpcTouchDamageComponent.hpp
@@ -6,6 +6,6 @@
 using NpcDamage_t = int;
 struct GiveNpcTouchDamageComponent : public Subject<NpcDamage_t>
 {
-    static const int TOP_COOLDOWN_MS = 750;
+    static const int TOP_COOLDOWN_MS = 1000;
     int cooldown_ms = TOP_COOLDOWN_MS;
 };

--- a/src/game-loop/include/components/damage/GiveNpcTouchDamageComponent.hpp
+++ b/src/game-loop/include/components/damage/GiveNpcTouchDamageComponent.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "patterns/Subject.hpp"
+#include "components/generic/PhysicsComponent.hpp"
+
+using NpcDamage_t = int;
+struct GiveNpcTouchDamageComponent : public Subject<NpcDamage_t>
+{
+    static const int TOP_COOLDOWN = 500;
+    int cooldown = TOP_COOLDOWN;
+    // TODO: Possibly amount of damage, if not always "1"
+};

--- a/src/game-loop/include/components/damage/GiveNpcTouchDamageComponent.hpp
+++ b/src/game-loop/include/components/damage/GiveNpcTouchDamageComponent.hpp
@@ -6,7 +6,6 @@
 using NpcDamage_t = int;
 struct GiveNpcTouchDamageComponent : public Subject<NpcDamage_t>
 {
-    static const int TOP_COOLDOWN = 500;
-    int cooldown = TOP_COOLDOWN;
-    // TODO: Possibly amount of damage, if not always "1"
+    static const int TOP_COOLDOWN_MS = 500;
+    int cooldown = TOP_COOLDOWN_MS;
 };

--- a/src/game-loop/include/components/damage/GiveNpcTouchDamageComponent.hpp
+++ b/src/game-loop/include/components/damage/GiveNpcTouchDamageComponent.hpp
@@ -6,6 +6,6 @@
 using NpcDamage_t = int;
 struct GiveNpcTouchDamageComponent : public Subject<NpcDamage_t>
 {
-    static const int TOP_COOLDOWN_MS = 500;
-    int cooldown = TOP_COOLDOWN_MS;
+    static const int TOP_COOLDOWN_MS = 750;
+    int cooldown_ms = TOP_COOLDOWN_MS;
 };

--- a/src/game-loop/include/components/damage/TakeFallDamageComponent.hpp
+++ b/src/game-loop/include/components/damage/TakeFallDamageComponent.hpp
@@ -8,7 +8,13 @@ class TakeFallDamageComponent : public Subject<FallDamage_t>
 {
 public:
     TakeFallDamageComponent() = default;
-    explicit TakeFallDamageComponent(FallDamage_t falling_damage) : _falling_damage(falling_damage) {}
+    explicit TakeFallDamageComponent(FallDamage_t falling_damage)
+        : _falling_damage(falling_damage)
+    {}
+    TakeFallDamageComponent(FallDamage_t falling_damage, float critical_spped)
+        : _falling_damage(falling_damage)
+        , _critical_speed(critical_spped)
+    {}
 
     bool update(const PhysicsComponent& physics)
     {

--- a/src/game-loop/include/components/damage/TakeNpcTouchDamageComponent.hpp
+++ b/src/game-loop/include/components/damage/TakeNpcTouchDamageComponent.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "patterns/Subject.hpp"
+#include "components/generic/PhysicsComponent.hpp"
+
+using NpcDamage_t = int;
+class TakeNpcTouchDamageComponent : public Subject<NpcDamage_t>
+{
+};

--- a/src/game-loop/include/components/generic/BlinkingComponent.hpp
+++ b/src/game-loop/include/components/generic/BlinkingComponent.hpp
@@ -32,6 +32,11 @@ public:
         return _remove_when_done && _timer_total_ms >= _total_time_ms;
     }
 
+    void reset_timer()
+    {
+        _timer_total_ms = 0;
+    }
+
     void set_original_quad_width(float width) { _original_quad_width = width; }
     void set_original_quad_height(float height) { _original_quad_height = height; }
 

--- a/src/game-loop/include/components/generic/BlinkingComponent.hpp
+++ b/src/game-loop/include/components/generic/BlinkingComponent.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+class BlinkingComponent
+{
+public:
+
+    BlinkingComponent() = default;
+    explicit BlinkingComponent(int interval_ms, int total_time_ms, bool remove_when_done)
+        : _interval_ms(interval_ms)
+        , _total_time_ms(total_time_ms)
+        , _remove_when_done(remove_when_done)
+    {}
+
+    void update(std::uint32_t delta_time_ms)
+    {
+        _timer_ms += delta_time_ms;
+        _timer_total_ms += delta_time_ms;
+
+        if (_timer_ms > _interval_ms * 2)
+        {
+            _timer_ms = 0;
+        }
+    }
+
+    bool is_transparent() const
+    {
+        return _timer_ms <= _interval_ms;
+    }
+
+    bool is_for_removal() const
+    {
+        return _remove_when_done && _timer_total_ms >= _total_time_ms;
+    }
+
+    void set_original_quad_width(float width) { _original_quad_width = width; }
+    void set_original_quad_height(float height) { _original_quad_height = height; }
+
+    float get_original_quad_width() const { return _original_quad_width; }
+    float get_original_quad_height() const { return _original_quad_height; }
+
+private:
+    int _interval_ms = 100;
+    int _total_time_ms = 1000;
+    bool _remove_when_done = true;
+
+    int _timer_total_ms = 0;
+    int _timer_ms = 0;
+
+    // As blinking is achieved through periodic dimension change to infinitely small:
+    float _original_quad_width = 0.0f;
+    float _original_quad_height = 0.0f;
+};

--- a/src/game-loop/include/components/generic/QuadComponent.hpp
+++ b/src/game-loop/include/components/generic/QuadComponent.hpp
@@ -31,6 +31,9 @@ public:
     float get_quad_width() const { return _quad_dimensions.width; }
     float get_quad_height() const { return _quad_dimensions.height; }
 
+    void set_quad_width(float width) { _quad_dimensions.width = width; }
+    void set_quad_height(float height) { _quad_dimensions.height = height; }
+
     Quad& get_quad() { return _quad; }
 
     void set_vertical_flip(bool v) { _vertical_flip = v; }

--- a/src/game-loop/include/components/specialized/MainDudeComponent.hpp
+++ b/src/game-loop/include/components/specialized/MainDudeComponent.hpp
@@ -25,12 +25,7 @@
 #include "main-dude/states/MainDudeDeadState.hpp"
 #include "main-dude/states/MainDudeStunnedState.hpp"
 #include "main-dude/MainDudeEvent.hpp"
-
-#include "components/generic/PhysicsComponent.hpp"
-#include "components/generic/PositionComponent.hpp"
-#include "components/generic/QuadComponent.hpp"
-#include "components/generic/AnimationComponent.hpp"
-#include "components/generic/ClimbingComponent.hpp"
+#include "main-dude/MainDudeObservers.hpp"
 
 #include <vector>
 #include <memory>
@@ -38,17 +33,6 @@
 class MainDudeBaseState;
 class Input;
 class MapTile;
-
-class MainDudeClimbingObserver : Observer<ClimbingEvent>
-{
-public:
-    explicit MainDudeClimbingObserver(entt::entity main_dude) : _main_dude(main_dude) {};
-    void on_notify(const ClimbingEvent* event) override;
-    ClimbingEvent get_last_event() const { return _last_event; }
-private:
-    const entt::entity _main_dude;
-    ClimbingEvent _last_event{};
-};
 
 class MainDudeComponent : public Subject<MainDudeEvent>
 {
@@ -64,12 +48,28 @@ public:
     void enter_standing_state();
     void enter_throwing_state();
     void enter_climbing_state();
+    void enter_stunned_state();
 
     bool entered_door() const { return _other.entered_door; }
 
     MainDudeClimbingObserver* get_climbing_observer()
     {
         return _climbing_observer.get();
+    }
+
+    MainDudeFallObserver* get_fall_observer()
+    {
+        return _fall_observer.get();
+    }
+
+    MainDudeDeathObserver* get_death_observer()
+    {
+        return _death_observer.get();
+    }
+
+    MainDudeNpcDamageObserver* get_npc_damage_observer()
+    {
+        return _npc_damage_observer.get();
     }
 
 private:
@@ -128,10 +128,12 @@ private:
     entt::entity _owner = entt::null;
 
     std::shared_ptr<MainDudeClimbingObserver> _climbing_observer;
+    std::shared_ptr<MainDudeFallObserver> _fall_observer;
+    std::shared_ptr<MainDudeDeathObserver> _death_observer;
+    std::shared_ptr<MainDudeNpcDamageObserver> _npc_damage_observer;
 
     static constexpr float DEFAULT_DELTA_X = 0.01f;
     static constexpr float DEFAULT_MAX_X_VELOCITY = 0.050f;
-    static constexpr float DEFAULT_MAX_Y_VELOCITY = 0.39f;
 
     static constexpr float MAX_RUNNING_VELOCITY_X = 0.15f;
     static constexpr float MAX_CRAWLING_VELOCITY_X = 0.008f;

--- a/src/game-loop/include/main-dude/MainDudeObservers.hpp
+++ b/src/game-loop/include/main-dude/MainDudeObservers.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "components/generic/PhysicsComponent.hpp"
+#include "components/generic/PositionComponent.hpp"
+#include "components/generic/QuadComponent.hpp"
+#include "components/generic/AnimationComponent.hpp"
+#include "components/generic/ClimbingComponent.hpp"
+#include "components/damage/TakeFallDamageComponent.hpp"
+#include "components/damage/TakeNpcTouchDamageComponent.hpp"
+#include "components/damage/HitpointComponent.hpp"
+
+class MainDudeClimbingObserver : Observer<ClimbingEvent>
+{
+public:
+    explicit MainDudeClimbingObserver(entt::entity main_dude) : _main_dude(main_dude) {};
+    void on_notify(const ClimbingEvent* event) override;
+    ClimbingEvent get_last_event() const { return _last_event; }
+private:
+    const entt::entity _main_dude;
+    ClimbingEvent _last_event{};
+};
+
+class MainDudeFallObserver : Observer<FallDamage_t>
+{
+public:
+    explicit MainDudeFallObserver(entt::entity main_dude) : _main_dude(main_dude) {};
+    void on_notify(const FallDamage_t * event) override;
+private:
+    const entt::entity _main_dude;
+};
+
+class MainDudeDeathObserver : Observer<DeathEvent>
+{
+public:
+    explicit MainDudeDeathObserver(entt::entity main_dude) : _main_dude(main_dude) {};
+    void on_notify(const DeathEvent * event) override;
+private:
+    const entt::entity _main_dude;
+};
+
+class MainDudeNpcDamageObserver : Observer<NpcDamage_t>
+{
+public:
+    explicit MainDudeNpcDamageObserver(entt::entity main_dude) : _main_dude(main_dude) {};
+    void on_notify(const NpcDamage_t * event) override;
+private:
+    const entt::entity _main_dude;
+};

--- a/src/game-loop/include/system/DamageSystem.hpp
+++ b/src/game-loop/include/system/DamageSystem.hpp
@@ -12,4 +12,5 @@ private:
     static void update_melee_damage();
     static void update_projectile_damage();
     static void update_jump_on_top_damage();
+    static void update_npc_touch_damage(std::uint32_t delta_time_ms);
 };

--- a/src/game-loop/include/system/RenderingSystem.hpp
+++ b/src/game-loop/include/system/RenderingSystem.hpp
@@ -24,6 +24,7 @@ private:
     void use_camera(CameraType camera_type);
     void use_model_view_camera();
     void use_screen_space_camera();
+    void update_blinking(std::uint32_t delta_time_ms) const;
 
     struct
     {

--- a/src/game-loop/src/game-loop/GameLoopPlayingState.cpp
+++ b/src/game-loop/src/game-loop/GameLoopPlayingState.cpp
@@ -189,7 +189,11 @@ void GameLoopPlayingState::on_notify(const MainDudeEvent* event)
             pause.hide(registry);
             pause.disable_input();
 
-            registry.destroy(_hud);
+            // FIXME
+            if (registry.valid(_hud))
+            {
+                registry.destroy(_hud);
+            }
             _hud = entt::null;
 
             break;

--- a/src/game-loop/src/game-loop/GameLoopPlayingState.cpp
+++ b/src/game-loop/src/game-loop/GameLoopPlayingState.cpp
@@ -189,11 +189,7 @@ void GameLoopPlayingState::on_notify(const MainDudeEvent* event)
             pause.hide(registry);
             pause.disable_input();
 
-            // FIXME
-            if (registry.valid(_hud))
-            {
-                registry.destroy(_hud);
-            }
+            registry.destroy(_hud);
             _hud = entt::null;
 
             break;

--- a/src/game-loop/src/main-dude/MainDudeComponent.cpp
+++ b/src/game-loop/src/main-dude/MainDudeComponent.cpp
@@ -35,12 +35,18 @@ MainDudeComponent::MainDudeComponent(entt::entity owner) : _owner(owner)
     _states.current->enter(*this);
 
     _climbing_observer = std::make_shared<MainDudeClimbingObserver>(owner);
+    _fall_observer = std::make_shared<MainDudeFallObserver>(owner);
+    _death_observer = std::make_shared<MainDudeDeathObserver>(owner);
+    _npc_damage_observer = std::make_shared<MainDudeNpcDamageObserver>(owner);
 }
 
 MainDudeComponent::MainDudeComponent(const MainDudeComponent& other) : _owner(other._owner)
 {
     _states.current = &_states.standing;
     _climbing_observer = other._climbing_observer;
+    _fall_observer = other._fall_observer;
+    _death_observer = other._death_observer;
+    _npc_damage_observer = other._npc_damage_observer;
 }
 
 void MainDudeComponent::update(uint32_t delta_time_ms)
@@ -85,6 +91,11 @@ MapTile* MainDudeComponent::is_overlaping_tile(MapTileType type, PhysicsComponen
 void MainDudeComponent::enter_standing_state()
 {
     enter_if_different(&_states.standing);
+}
+
+void MainDudeComponent::enter_stunned_state()
+{
+    enter_if_different(&_states.stunned);
 }
 
 void MainDudeComponent::enter_climbing_state()
@@ -162,23 +173,5 @@ void MainDudeComponent::enter_if_different(MainDudeBaseState* new_state)
         _states.current->exit(*this);
         _states.current = new_state;
         _states.current->enter(*this);
-    }
-}
-
-void MainDudeClimbingObserver::on_notify(const ClimbingEvent *event)
-{
-    auto& registry = EntityRegistry::instance().get_registry();
-    auto& main_dude_component = registry.get<MainDudeComponent>(_main_dude);
-
-    _last_event = *event;
-
-    switch (_last_event.event_type)
-    {
-        case ClimbingEventType::STARTED_CLIMBING_LADDER:
-        case ClimbingEventType::STARTED_CLIMBING_ROPE:
-        {
-            main_dude_component.enter_climbing_state();
-            break;
-        }
     }
 }

--- a/src/game-loop/src/main-dude/MainDudeObservers.cpp
+++ b/src/game-loop/src/main-dude/MainDudeObservers.cpp
@@ -1,0 +1,61 @@
+#include "main-dude/MainDudeObservers.hpp"
+#include "components/specialized/MainDudeComponent.hpp"
+#include "EntityRegistry.hpp"
+#include "other/Inventory.hpp"
+
+void MainDudeClimbingObserver::on_notify(const ClimbingEvent *event)
+{
+    auto& registry = EntityRegistry::instance().get_registry();
+    auto& main_dude_component = registry.get<MainDudeComponent>(_main_dude);
+
+    _last_event = *event;
+
+    switch (_last_event.event_type)
+    {
+        case ClimbingEventType::STARTED_CLIMBING_LADDER:
+        case ClimbingEventType::STARTED_CLIMBING_ROPE:
+        {
+            main_dude_component.enter_climbing_state();
+            break;
+        }
+    }
+}
+
+void MainDudeNpcDamageObserver::on_notify(const NpcDamage_t *event)
+{
+    auto& registry = EntityRegistry::instance().get_registry();
+    auto& main_dude_component = registry.get<MainDudeComponent>(_main_dude);
+
+    Inventory::instance().remove_hearts(*event);
+
+    if (Inventory::instance().get_hearts() == 0)
+    {
+        main_dude_component.enter_dead_state();
+    }
+}
+
+void MainDudeDeathObserver::on_notify(const DeathEvent *event)
+{
+    auto& registry = EntityRegistry::instance().get_registry();
+    auto& main_dude_component = registry.get<MainDudeComponent>(_main_dude);
+
+    main_dude_component.notify(MainDudeEvent::DIED);
+    main_dude_component.enter_dead_state();
+}
+
+void MainDudeFallObserver::on_notify(const FallDamage_t *event)
+{
+    auto& registry = EntityRegistry::instance().get_registry();
+    auto& main_dude_component = registry.get<MainDudeComponent>(_main_dude);
+
+    Inventory::instance().remove_hearts(*event);
+
+    if (Inventory::instance().get_hearts() == 0)
+    {
+        main_dude_component.enter_dead_state();
+    }
+    else
+    {
+        main_dude_component.enter_stunned_state();
+    }
+}

--- a/src/game-loop/src/main-dude/MainDudeObservers.cpp
+++ b/src/game-loop/src/main-dude/MainDudeObservers.cpp
@@ -42,6 +42,11 @@ void MainDudeNpcDamageObserver::on_notify(const NpcDamage_t *event)
 
         registry.emplace<BlinkingComponent>(_main_dude, interval_ms, total_time, remove_on_done);
     }
+    else
+    {
+        auto& blinking_component = registry.get<BlinkingComponent>(_main_dude);
+        blinking_component.reset_timer();
+    }
 }
 
 void MainDudeDeathObserver::on_notify(const DeathEvent *event)

--- a/src/game-loop/src/main-dude/MainDudeObservers.cpp
+++ b/src/game-loop/src/main-dude/MainDudeObservers.cpp
@@ -1,5 +1,7 @@
 #include "main-dude/MainDudeObservers.hpp"
 #include "components/specialized/MainDudeComponent.hpp"
+#include "components/generic/BlinkingComponent.hpp"
+#include "components/damage/GiveNpcTouchDamageComponent.hpp"
 #include "EntityRegistry.hpp"
 #include "other/Inventory.hpp"
 
@@ -31,6 +33,14 @@ void MainDudeNpcDamageObserver::on_notify(const NpcDamage_t *event)
     if (Inventory::instance().get_hearts() == 0)
     {
         main_dude_component.enter_dead_state();
+    }
+    else if (!registry.has<BlinkingComponent>(_main_dude))
+    {
+        const int interval_ms = 50;
+        const int total_time = GiveNpcTouchDamageComponent::TOP_COOLDOWN_MS;
+        const int remove_on_done = true;
+
+        registry.emplace<BlinkingComponent>(_main_dude, interval_ms, total_time, remove_on_done);
     }
 }
 

--- a/src/game-loop/src/main-dude/states/MainDudeFallingState.cpp
+++ b/src/game-loop/src/main-dude/states/MainDudeFallingState.cpp
@@ -83,20 +83,7 @@ MainDudeBaseState* MainDudeFallingState::update(MainDudeComponent& dude, uint32_
 
     if (physics.is_bottom_collision())
     {
-        if (_last_y_speed >= MainDudeComponent::DEFAULT_MAX_Y_VELOCITY)
-        {
-            Inventory::instance().remove_hearts(1);
-
-            if (Inventory::instance().get_hearts() == 0)
-            {
-                return &dude._states.dead;
-            }
-            else
-            {
-                return &dude._states.stunned;
-            }
-        }
-        else if (physics.get_x_velocity() == 0.0f)
+        if (physics.get_x_velocity() == 0.0f)
         {
             return &dude._states.standing;
         }

--- a/src/game-loop/src/prefabs/main-dude/MainDude.cpp
+++ b/src/game-loop/src/prefabs/main-dude/MainDude.cpp
@@ -3,7 +3,6 @@
 #include "prefabs/items/RopeSpawner.hpp"
 #include "prefabs/items/Whip.hpp"
 
-#include "components/damage/GiveJumpOnTopDamage.hpp"
 #include "components/generic/PositionComponent.hpp"
 #include "components/generic/ClimbingComponent.hpp"
 #include "components/generic/QuadComponent.hpp"
@@ -12,10 +11,20 @@
 #include "components/generic/ItemCarrierComponent.hpp"
 #include "components/generic/MeshComponent.hpp"
 #include "components/generic/InputComponent.hpp"
+#include "components/damage/HitpointComponent.hpp"
+#include "components/damage/TakeNpcTouchDamageComponent.hpp"
+#include "components/damage/GiveJumpOnTopDamage.hpp"
+#include "components/damage/TakeFallDamageComponent.hpp"
 #include "components/specialized/MainDudeComponent.hpp"
 
 #include "EntityRegistry.hpp"
 #include "TextureType.hpp"
+#include "other/Inventory.hpp"
+
+namespace
+{
+    static constexpr float DEFAULT_MAX_Y_VELOCITY = 0.39f;
+}
 
 namespace prefabs
 {
@@ -47,6 +56,7 @@ namespace prefabs
         registry.emplace<PhysicsComponent>(entity, physics);
         registry.emplace<MeshComponent>(entity, mesh);
         registry.emplace<InputComponent>(entity, input);
+        registry.emplace<HitpointComponent>(entity, Inventory::instance().get_hearts());
         registry.emplace<HorizontalOrientationComponent>(entity);
         registry.emplace<ItemCarrierComponent>(entity, item_carrier);
         registry.emplace<GiveJumpOnTopDamageComponent>(entity, 1);
@@ -58,6 +68,14 @@ namespace prefabs
         ClimbingComponent climbing;
         climbing.add_observer(reinterpret_cast<Observer<ClimbingEvent> *>(main_dude.get_climbing_observer()));
         registry.emplace<ClimbingComponent>(entity, climbing);
+
+        TakeFallDamageComponent take_fall_damage(1, DEFAULT_MAX_Y_VELOCITY);
+        take_fall_damage.add_observer(reinterpret_cast<Observer<FallDamage_t> *>(main_dude.get_fall_observer()));
+        registry.emplace<TakeFallDamageComponent>(entity, take_fall_damage);
+
+        TakeNpcTouchDamageComponent take_npc_damage;
+        take_npc_damage.add_observer(reinterpret_cast<Observer<NpcDamage_t> *>(main_dude.get_npc_damage_observer()));
+        registry.emplace<TakeNpcTouchDamageComponent>(entity, take_npc_damage);
 
         {
             auto& carrier = registry.get<ItemCarrierComponent>(entity);

--- a/src/game-loop/src/prefabs/npc/Bat.cpp
+++ b/src/game-loop/src/prefabs/npc/Bat.cpp
@@ -15,6 +15,7 @@
 #include "components/damage/HitpointComponent.hpp"
 #include "components/damage/TakeProjectileDamageComponent.hpp"
 #include "components/damage/TakeMeleeDamageComponent.hpp"
+#include "components/damage/GiveNpcTouchDamageComponent.hpp"
 
 #include "audio/Audio.hpp"
 #include "EntityRegistry.hpp"
@@ -226,6 +227,7 @@ entt::entity prefabs::Bat::create(float pos_x_center, float pos_y_center)
     registry.emplace<TakeMeleeDamageComponent>(entity);
     registry.emplace<TakeJumpOnTopDamageComponent>(entity);
     registry.emplace<NpcTypeComponent>(entity, NpcType::BAT);
+    registry.emplace<GiveNpcTouchDamageComponent>(entity);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/npc/Caveman.cpp
+++ b/src/game-loop/src/prefabs/npc/Caveman.cpp
@@ -14,6 +14,7 @@
 #include "components/damage/TakeProjectileDamageComponent.hpp"
 #include "components/damage/TakeMeleeDamageComponent.hpp"
 #include "components/damage/TakeJumpOnTopDamage.hpp"
+#include "components/damage/GiveNpcTouchDamageComponent.hpp"
 
 #include "EntityRegistry.hpp"
 #include "TextureType.hpp"
@@ -176,6 +177,7 @@ entt::entity prefabs::Caveman::create(float pos_x_center, float pos_y_center)
     registry.emplace<HitpointComponent>(entity, hitpoints);
     registry.emplace<TakeJumpOnTopDamageComponent>(entity);
     registry.emplace<NpcTypeComponent>(entity, NpcType::CAVEMAN);
+    registry.emplace<GiveNpcTouchDamageComponent>(entity);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/npc/Skeleton.cpp
+++ b/src/game-loop/src/prefabs/npc/Skeleton.cpp
@@ -16,6 +16,7 @@
 #include "components/damage/HitpointComponent.hpp"
 #include "components/damage/TakeMeleeDamageComponent.hpp"
 #include "components/damage/TakeJumpOnTopDamage.hpp"
+#include "components/damage/GiveNpcTouchDamageComponent.hpp"
 
 #include "EntityRegistry.hpp"
 #include "TextureType.hpp"
@@ -183,6 +184,7 @@ entt::entity prefabs::Skeleton::create(float pos_x_center, float pos_y_center)
     registry.emplace<TakeMeleeDamageComponent>(entity);
     registry.emplace<TakeJumpOnTopDamageComponent>(entity);
     registry.emplace<NpcTypeComponent>(entity, NpcType::SKELETON);
+    registry.emplace<GiveNpcTouchDamageComponent>(entity);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/npc/Snake.cpp
+++ b/src/game-loop/src/prefabs/npc/Snake.cpp
@@ -14,6 +14,7 @@
 #include "components/damage/TakeProjectileDamageComponent.hpp"
 #include "components/damage/TakeMeleeDamageComponent.hpp"
 #include "components/damage/TakeJumpOnTopDamage.hpp"
+#include "components/damage/GiveNpcTouchDamageComponent.hpp"
 
 #include "EntityRegistry.hpp"
 #include "TextureType.hpp"
@@ -177,6 +178,7 @@ entt::entity prefabs::Snake::create(float pos_x_center, float pos_y_center)
     registry.emplace<TakeMeleeDamageComponent>(entity);
     registry.emplace<TakeJumpOnTopDamageComponent>(entity);
     registry.emplace<NpcTypeComponent>(entity, NpcType::SNAKE);
+    registry.emplace<GiveNpcTouchDamageComponent>(entity);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/npc/Spider.cpp
+++ b/src/game-loop/src/prefabs/npc/Spider.cpp
@@ -15,6 +15,7 @@
 #include "components/damage/TakeProjectileDamageComponent.hpp"
 #include "components/damage/TakeMeleeDamageComponent.hpp"
 #include "components/damage/TakeJumpOnTopDamage.hpp"
+#include "components/damage/GiveNpcTouchDamageComponent.hpp"
 
 #include "EntityRegistry.hpp"
 #include "TextureType.hpp"
@@ -203,6 +204,7 @@ entt::entity prefabs::Spider::create(float pos_x_center, float pos_y_center, boo
     registry.emplace<TakeMeleeDamageComponent>(entity);
     registry.emplace<TakeJumpOnTopDamageComponent>(entity);
     registry.emplace<NpcTypeComponent>(entity, NpcType::SPIDER);
+    registry.emplace<GiveNpcTouchDamageComponent>(entity);
 
     if (triggered)
     {

--- a/src/game-loop/src/system/DamageSystem.cpp
+++ b/src/game-loop/src/system/DamageSystem.cpp
@@ -274,9 +274,9 @@ void DamageSystem::update_npc_touch_damage(std::uint32_t delta_time_ms)
             // TODO: Rendering system should somehow render just-taken-damage entity as half-transparent or blinking
             //       between 0 to 1 opacity
 
-            if (give_damage.cooldown > 0)
+            if (give_damage.cooldown_ms > 0)
             {
-                give_damage.cooldown -= delta_time_ms;
+                give_damage.cooldown_ms -= delta_time_ms;
                 return;
             }
 
@@ -284,7 +284,7 @@ void DamageSystem::update_npc_touch_damage(std::uint32_t delta_time_ms)
             {
                 take_damage_hitpoints.remove_hitpoints(default_npc_touch_damage);
                 take_damage.notify(default_npc_touch_damage);
-                give_damage.cooldown = GiveNpcTouchDamageComponent::TOP_COOLDOWN_MS;
+                give_damage.cooldown_ms = GiveNpcTouchDamageComponent::TOP_COOLDOWN_MS;
 
                 if (take_damage_hitpoints.get_hitpoints() <= 0)
                 {

--- a/src/game-loop/src/system/DamageSystem.cpp
+++ b/src/game-loop/src/system/DamageSystem.cpp
@@ -284,7 +284,7 @@ void DamageSystem::update_npc_touch_damage(std::uint32_t delta_time_ms)
             {
                 take_damage_hitpoints.remove_hitpoints(default_npc_touch_damage);
                 take_damage.notify(default_npc_touch_damage);
-                give_damage.cooldown = GiveNpcTouchDamageComponent::TOP_COOLDOWN;
+                give_damage.cooldown = GiveNpcTouchDamageComponent::TOP_COOLDOWN_MS;
 
                 if (take_damage_hitpoints.get_hitpoints() <= 0)
                 {

--- a/src/game-loop/src/system/DamageSystem.cpp
+++ b/src/game-loop/src/system/DamageSystem.cpp
@@ -271,9 +271,6 @@ void DamageSystem::update_npc_touch_damage(std::uint32_t delta_time_ms)
                                            PhysicsComponent& give_damage_physics,
                                            PositionComponent& give_damage_position)
         {
-            // TODO: Rendering system should somehow render just-taken-damage entity as half-transparent or blinking
-            //       between 0 to 1 opacity
-
             if (give_damage.cooldown_ms > 0)
             {
                 give_damage.cooldown_ms -= delta_time_ms;

--- a/src/game-loop/src/system/DamageSystem.cpp
+++ b/src/game-loop/src/system/DamageSystem.cpp
@@ -257,7 +257,6 @@ void DamageSystem::update_npc_touch_damage(std::uint32_t delta_time_ms)
 
     auto &registry = EntityRegistry::instance().get_registry();
 
-    // FIXME: Can these 2 collections overlap?
     auto bodies_taking_damage = registry.view<TakeNpcTouchDamageComponent, HitpointComponent, PhysicsComponent, PositionComponent>();
     auto bodies_giving_damage = registry.view<GiveNpcTouchDamageComponent, PhysicsComponent, PositionComponent>();
 


### PR DESCRIPTION
Changes:

* Added `GiveNpcTouchDamageComponent` and applied it to all NPC's (snake, bat, spider, skeleton, caveman)
* Added `TakeNpcTouchDamageComponent` and applied it to main dude
* Checking collisions between the new NPC damage components in `DamageSystem`
* Added `BlinkingComponent` and applying it on main dude taken damage.

Does not include damage taken from projectiles (i.e arrows, falling rocks).