### PR TITLE
(extended) explosion

### DIFF
--- a/src/game-loop/CMakeLists.txt
+++ b/src/game-loop/CMakeLists.txt
@@ -86,6 +86,7 @@ add_library(GameLoop STATIC
         include/components/generic/AnimationComponent.hpp
         include/components/generic/MeshComponent.hpp
         include/components/generic/ActivableComponent.hpp
+        include/components/generic/ZoneComponent.hpp
         include/components/generic/NpcTypeComponent.hpp
         include/components/generic/ClimbingComponent.hpp
         include/components/generic/BlinkingComponent.hpp
@@ -106,6 +107,8 @@ add_library(GameLoop STATIC
         include/components/damage/TakeMeleeDamageComponent.hpp
         include/components/damage/TakeTileCollisionDamageComponent.hpp
         include/components/damage/TakeJumpOnTopDamage.hpp
+        include/components/damage/GiveExplosionDamageComponent.hpp
+        include/components/damage/TakeExplosionDamageComponent.hpp
 
         # Prefabs:
 
@@ -271,7 +274,7 @@ add_library(GameLoop STATIC
         include/other/LootCollectedEvent.hpp
         include/other/NpcType.hpp
         include/other/ParticleGenerator.hpp
-        include/components/generic/ZoneComponent.hpp include/components/damage/GiveExplosionDamageComponent.hpp include/components/damage/TakeExplosionDamageComponent.hpp)
+)
 
 target_include_directories(GameLoop
         PRIVATE include interface

--- a/src/game-loop/CMakeLists.txt
+++ b/src/game-loop/CMakeLists.txt
@@ -271,7 +271,7 @@ add_library(GameLoop STATIC
         include/other/LootCollectedEvent.hpp
         include/other/NpcType.hpp
         include/other/ParticleGenerator.hpp
-)
+        include/components/generic/ZoneComponent.hpp include/components/damage/GiveExplosionDamageComponent.hpp include/components/damage/TakeExplosionDamageComponent.hpp)
 
 target_include_directories(GameLoop
         PRIVATE include interface

--- a/src/game-loop/include/components/damage/GiveExplosionDamageComponent.hpp
+++ b/src/game-loop/include/components/damage/GiveExplosionDamageComponent.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "patterns/Subject.hpp"
+
+struct GiveExplosionDamageComponent
+{
+    // No damage specified - assuming bomb takes all hitpoints
+
+    // FIXME:
+    char dummy_member_for_entt;
+};

--- a/src/game-loop/include/components/damage/GiveExplosionDamageComponent.hpp
+++ b/src/game-loop/include/components/damage/GiveExplosionDamageComponent.hpp
@@ -4,8 +4,6 @@
 
 struct GiveExplosionDamageComponent
 {
-    // No damage specified - assuming bomb takes all hitpoints
-
-    // FIXME:
+    // https://github.com/skypjack/entt/issues/330
     char dummy_member_for_entt;
 };

--- a/src/game-loop/include/components/damage/TakeExplosionDamageComponent.hpp
+++ b/src/game-loop/include/components/damage/TakeExplosionDamageComponent.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "patterns/Subject.hpp"
+
+class TakeExplosionDamageComponent
+{
+    // TODO: Explosion notification? i.e could flame main dude in notification handler by attaching flame particle
+
+    // FIXME:
+    char dummy_member_for_entt;
+};

--- a/src/game-loop/include/components/damage/TakeExplosionDamageComponent.hpp
+++ b/src/game-loop/include/components/damage/TakeExplosionDamageComponent.hpp
@@ -2,7 +2,10 @@
 
 #include "patterns/Subject.hpp"
 
-class TakeExplosionDamageComponent
+struct ExplosionDamageTakenEvent
 {
-    // TODO: Explosion notification? i.e could flame main dude in notification handler by attaching flame particle
+};
+
+class TakeExplosionDamageComponent : public Subject<ExplosionDamageTakenEvent>
+{
 };

--- a/src/game-loop/include/components/damage/TakeExplosionDamageComponent.hpp
+++ b/src/game-loop/include/components/damage/TakeExplosionDamageComponent.hpp
@@ -5,7 +5,4 @@
 class TakeExplosionDamageComponent
 {
     // TODO: Explosion notification? i.e could flame main dude in notification handler by attaching flame particle
-
-    // FIXME:
-    char dummy_member_for_entt;
 };

--- a/src/game-loop/include/components/generic/PhysicsComponent.hpp
+++ b/src/game-loop/include/components/generic/PhysicsComponent.hpp
@@ -2,6 +2,7 @@
 
 #include "other/PhysicsComponentType.hpp"
 #include "PositionComponent.hpp"
+#include "ZoneComponent.hpp"
 
 #include <cstdint>
 #include <functional>
@@ -14,6 +15,7 @@ public:
     PhysicsComponent() = default;
 
     bool is_collision(PhysicsComponent& other_physics, PositionComponent& other_position, PositionComponent& this_position) const;
+    bool is_collision(ZoneComponent& other_zone, PositionComponent& other_position, PositionComponent& this_position) const;
 
     void update(uint32_t delta_time_ms,PositionComponent& position);
 

--- a/src/game-loop/include/components/generic/ZoneComponent.hpp
+++ b/src/game-loop/include/components/generic/ZoneComponent.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+struct ZoneComponent
+{
+    float width;
+    float height;
+};

--- a/src/game-loop/include/components/specialized/MainDudeComponent.hpp
+++ b/src/game-loop/include/components/specialized/MainDudeComponent.hpp
@@ -72,6 +72,11 @@ public:
         return _npc_damage_observer.get();
     }
 
+    MainDudeExplosionDamageObserver* get_explosion_damage_observer()
+    {
+        return _explosion_observer.get();
+    }
+
 private:
 
     void enter_if_different(MainDudeBaseState*);
@@ -131,6 +136,7 @@ private:
     std::shared_ptr<MainDudeFallObserver> _fall_observer;
     std::shared_ptr<MainDudeDeathObserver> _death_observer;
     std::shared_ptr<MainDudeNpcDamageObserver> _npc_damage_observer;
+    std::shared_ptr<MainDudeExplosionDamageObserver> _explosion_observer;
 
     static constexpr float DEFAULT_DELTA_X = 0.01f;
     static constexpr float DEFAULT_MAX_X_VELOCITY = 0.050f;

--- a/src/game-loop/include/main-dude/MainDudeObservers.hpp
+++ b/src/game-loop/include/main-dude/MainDudeObservers.hpp
@@ -7,6 +7,7 @@
 #include "components/generic/ClimbingComponent.hpp"
 #include "components/damage/TakeFallDamageComponent.hpp"
 #include "components/damage/TakeNpcTouchDamageComponent.hpp"
+#include "components/damage/TakeExplosionDamageComponent.hpp"
 #include "components/damage/HitpointComponent.hpp"
 
 class MainDudeClimbingObserver : Observer<ClimbingEvent>
@@ -43,6 +44,15 @@ class MainDudeNpcDamageObserver : Observer<NpcDamage_t>
 public:
     explicit MainDudeNpcDamageObserver(entt::entity main_dude) : _main_dude(main_dude) {};
     void on_notify(const NpcDamage_t * event) override;
+private:
+    const entt::entity _main_dude;
+};
+
+class MainDudeExplosionDamageObserver : Observer<ExplosionDamageTakenEvent>
+{
+public:
+    explicit MainDudeExplosionDamageObserver(entt::entity main_dude) : _main_dude(main_dude) {};
+    void on_notify(const ExplosionDamageTakenEvent * event) override;
 private:
     const entt::entity _main_dude;
 };

--- a/src/game-loop/include/system/DamageSystem.hpp
+++ b/src/game-loop/include/system/DamageSystem.hpp
@@ -13,4 +13,5 @@ private:
     static void update_projectile_damage();
     static void update_jump_on_top_damage();
     static void update_npc_touch_damage(std::uint32_t delta_time_ms);
+    static void update_explosion_damage();
 };

--- a/src/game-loop/src/components/generic/PhysicsComponent.cpp
+++ b/src/game-loop/src/components/generic/PhysicsComponent.cpp
@@ -229,6 +229,18 @@ PhysicsComponent::PhysicsComponent(float width, float height) : _dimensions{widt
 {
 }
 
+bool PhysicsComponent::is_collision(ZoneComponent& other_zone, PositionComponent& other_position, PositionComponent& this_position) const
+{
+    const float half_w = _dimensions.width / 2.0f;
+    const float half_h = _dimensions.height / 2.0f;
+
+    const float other_half_w = other_zone.width / 2.0f;
+    const float other_half_h = other_zone.height / 2.0f;
+
+    return this_position.x_center + half_w > other_position.x_center - other_half_w && this_position.x_center - half_w < other_position.x_center + other_half_w &&
+           this_position.y_center + half_h > other_position.y_center - other_half_h && this_position.y_center - half_h < other_position.y_center + other_half_h;
+}
+
 bool PhysicsComponent::is_collision(PhysicsComponent& other_physics, PositionComponent& other_position, PositionComponent& this_position) const
 {
     const float half_w = _dimensions.width / 2.0f;

--- a/src/game-loop/src/components/specialized/LevelSummaryOverlayComponent.cpp
+++ b/src/game-loop/src/components/specialized/LevelSummaryOverlayComponent.cpp
@@ -230,10 +230,13 @@ void LevelSummaryOverlayComponent::update(uint32_t delta_time_ms)
     const auto& killed_events = _level_summary_tracker->get_npc_killed_events();
 
     elements_appearing = std::floor<int>(static_cast<float>(_kills_appearing_timer) / 150.0f);
+
+    std::size_t added_icons = 0;
+
     for (std::size_t index = _kills_spawned; index < elements_appearing && index < killed_events.size(); index++)
     {
         auto& current_event = killed_events[index];
-        float x = 6.75f + (0.5 * index);
+        float x = 6.75f + (0.5 * added_icons);
         float y = 4.25f;
 
         switch (current_event)
@@ -275,5 +278,6 @@ void LevelSummaryOverlayComponent::update(uint32_t delta_time_ms)
             }
         }
         _kills_spawned++;
+        added_icons++;
     }
 }

--- a/src/game-loop/src/game-loop/GameLoopPlayingState.cpp
+++ b/src/game-loop/src/game-loop/GameLoopPlayingState.cpp
@@ -189,7 +189,10 @@ void GameLoopPlayingState::on_notify(const MainDudeEvent* event)
             pause.hide(registry);
             pause.disable_input();
 
-            registry.destroy(_hud);
+            if (registry.valid(_hud))
+            {
+                registry.destroy(_hud);
+            }
             _hud = entt::null;
 
             break;

--- a/src/game-loop/src/main-dude/MainDudeComponent.cpp
+++ b/src/game-loop/src/main-dude/MainDudeComponent.cpp
@@ -38,6 +38,7 @@ MainDudeComponent::MainDudeComponent(entt::entity owner) : _owner(owner)
     _fall_observer = std::make_shared<MainDudeFallObserver>(owner);
     _death_observer = std::make_shared<MainDudeDeathObserver>(owner);
     _npc_damage_observer = std::make_shared<MainDudeNpcDamageObserver>(owner);
+    _explosion_observer = std::make_shared<MainDudeExplosionDamageObserver>(owner);
 }
 
 MainDudeComponent::MainDudeComponent(const MainDudeComponent& other) : _owner(other._owner)
@@ -47,6 +48,7 @@ MainDudeComponent::MainDudeComponent(const MainDudeComponent& other) : _owner(ot
     _fall_observer = other._fall_observer;
     _death_observer = other._death_observer;
     _npc_damage_observer = other._npc_damage_observer;
+    _explosion_observer = other._explosion_observer;
 }
 
 void MainDudeComponent::update(uint32_t delta_time_ms)

--- a/src/game-loop/src/main-dude/MainDudeObservers.cpp
+++ b/src/game-loop/src/main-dude/MainDudeObservers.cpp
@@ -2,6 +2,7 @@
 #include "components/specialized/MainDudeComponent.hpp"
 #include "components/generic/BlinkingComponent.hpp"
 #include "components/damage/GiveNpcTouchDamageComponent.hpp"
+#include "components/generic/ParticleEmitterComponent.hpp"
 #include "EntityRegistry.hpp"
 #include "other/Inventory.hpp"
 
@@ -21,6 +22,24 @@ void MainDudeClimbingObserver::on_notify(const ClimbingEvent *event)
             break;
         }
     }
+}
+
+void MainDudeExplosionDamageObserver::on_notify(const ExplosionDamageTakenEvent *event)
+{
+    auto& registry = EntityRegistry::instance().get_registry();
+
+    if (registry.has<ParticleEmitterComponent>(_main_dude))
+    {
+        return;
+    }
+
+    ParticleEmitterComponent particle_emitter;
+
+    particle_emitter.interval_ms = 250;
+    particle_emitter.particle_type = ParticleType::FLAME_TRAIL;
+    particle_emitter.time_since_last_emission_ms = 0;
+
+    registry.emplace<ParticleEmitterComponent>(_main_dude, particle_emitter);
 }
 
 void MainDudeNpcDamageObserver::on_notify(const NpcDamage_t *event)

--- a/src/game-loop/src/prefabs/effects/Explosion.cpp
+++ b/src/game-loop/src/prefabs/effects/Explosion.cpp
@@ -5,9 +5,10 @@
 #include "components/generic/MeshComponent.hpp"
 #include "components/generic/AnimationComponent.hpp"
 #include "components/generic/TimeLimitComponent.hpp"
+#include "components/generic/ZoneComponent.hpp"
+#include "components/damage/GiveExplosionDamageComponent.hpp"
 
 #include "EntityRegistry.hpp"
-#include "TextureBank.hpp"
 #include "TextureType.hpp"
 #include "spritesheet-frames/CollectiblesSpritesheetFrames.hpp"
 
@@ -22,8 +23,11 @@ entt::entity prefabs::Explosion::create(float pos_x_center, float pos_y_center)
 
     const auto entity = registry.create();
 
+    const float width = 4.0f;
+    const float height = 4.0f;
+
     PositionComponent position(pos_x_center, pos_y_center);
-    QuadComponent quad(TextureType::COLLECTIBLES, 4, 4);
+    QuadComponent quad(TextureType::COLLECTIBLES, width, height);
     MeshComponent mesh;
     AnimationComponent animation;
 
@@ -41,6 +45,25 @@ entt::entity prefabs::Explosion::create(float pos_x_center, float pos_y_center)
     registry.emplace<MeshComponent>(entity, mesh);
     registry.emplace<AnimationComponent>(entity, animation);
     registry.emplace<TimeLimitComponent>(entity, 400);
+    registry.emplace<ZoneComponent>(entity, width, height);
+    registry.emplace<GiveExplosionDamageComponent>(entity);
+
+    // TODO: ZoneComponent (consisting of just dimensions)
+    // TODO: Bomb explosion should create an entity consisting of:
+    //       * ZoneComponent <- To have area of influence
+    //       * PositionComponent <- ditto
+    //       * TimeLimitComponent <- To dissappear over time
+    //       * GiveNpcDamageComponent <- To kill main dude
+    //       * GiveMeleeDamageComponent <- To kill NPC's
+    //
+    // ^ Or specifically, GiveExplosionDamageComponent? Should it require implementing new observers?
+    // Or, GiveZoneDamageComponent/TakeZoneDamageComponent
+    // Technically bombs give kill instantly (max damage), so they are unique in this respect.
+    // Should zone be used inside physics component? Function for checking overlap?
+    // Or, just use PhysicsComponent, since it defines w/h, just disable gravity?
+    //
+    // Should width/height be excluded from physics component? Theoretically no, as w/h is integral part of PhysicsComponent and
+    // makes no sense without it
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/effects/Explosion.cpp
+++ b/src/game-loop/src/prefabs/effects/Explosion.cpp
@@ -48,22 +48,5 @@ entt::entity prefabs::Explosion::create(float pos_x_center, float pos_y_center)
     registry.emplace<ZoneComponent>(entity, width, height);
     registry.emplace<GiveExplosionDamageComponent>(entity);
 
-    // TODO: ZoneComponent (consisting of just dimensions)
-    // TODO: Bomb explosion should create an entity consisting of:
-    //       * ZoneComponent <- To have area of influence
-    //       * PositionComponent <- ditto
-    //       * TimeLimitComponent <- To dissappear over time
-    //       * GiveNpcDamageComponent <- To kill main dude
-    //       * GiveMeleeDamageComponent <- To kill NPC's
-    //
-    // ^ Or specifically, GiveExplosionDamageComponent? Should it require implementing new observers?
-    // Or, GiveZoneDamageComponent/TakeZoneDamageComponent
-    // Technically bombs give kill instantly (max damage), so they are unique in this respect.
-    // Should zone be used inside physics component? Function for checking overlap?
-    // Or, just use PhysicsComponent, since it defines w/h, just disable gravity?
-    //
-    // Should width/height be excluded from physics component? Theoretically no, as w/h is integral part of PhysicsComponent and
-    // makes no sense without it
-
     return entity;
 }

--- a/src/game-loop/src/prefabs/main-dude/MainDude.cpp
+++ b/src/game-loop/src/prefabs/main-dude/MainDude.cpp
@@ -61,7 +61,6 @@ namespace prefabs
         registry.emplace<HorizontalOrientationComponent>(entity);
         registry.emplace<ItemCarrierComponent>(entity, item_carrier);
         registry.emplace<GiveJumpOnTopDamageComponent>(entity, 1);
-        registry.emplace<TakeExplosionDamageComponent>(entity);
 
         // Initialization order is important in this case - MainDudeComponent must be the last to create.
         MainDudeComponent main_dude(entity);
@@ -82,6 +81,10 @@ namespace prefabs
         TakeNpcTouchDamageComponent take_npc_damage;
         take_npc_damage.add_observer(reinterpret_cast<Observer<NpcDamage_t> *>(main_dude.get_npc_damage_observer()));
         registry.emplace<TakeNpcTouchDamageComponent>(entity, take_npc_damage);
+
+        TakeExplosionDamageComponent take_explosion_damage;
+        take_explosion_damage.add_observer(reinterpret_cast<Observer<ExplosionDamageTakenEvent> *>(main_dude.get_explosion_damage_observer()));
+        registry.emplace<TakeExplosionDamageComponent>(entity, take_explosion_damage);
 
         {
             auto& carrier = registry.get<ItemCarrierComponent>(entity);

--- a/src/game-loop/src/prefabs/main-dude/MainDude.cpp
+++ b/src/game-loop/src/prefabs/main-dude/MainDude.cpp
@@ -14,6 +14,7 @@
 #include "components/damage/HitpointComponent.hpp"
 #include "components/damage/TakeNpcTouchDamageComponent.hpp"
 #include "components/damage/GiveJumpOnTopDamage.hpp"
+#include "components/damage/TakeExplosionDamageComponent.hpp"
 #include "components/damage/TakeFallDamageComponent.hpp"
 #include "components/specialized/MainDudeComponent.hpp"
 
@@ -33,7 +34,8 @@ namespace prefabs
         return create(0, 0);
     }
 
-    entt::entity MainDude::create(float pos_x_center, float pos_y_center) {
+    entt::entity MainDude::create(float pos_x_center, float pos_y_center)
+    {
         auto &registry = EntityRegistry::instance().get_registry();
 
         const auto entity = registry.create();
@@ -56,14 +58,18 @@ namespace prefabs
         registry.emplace<PhysicsComponent>(entity, physics);
         registry.emplace<MeshComponent>(entity, mesh);
         registry.emplace<InputComponent>(entity, input);
-        registry.emplace<HitpointComponent>(entity, Inventory::instance().get_hearts());
         registry.emplace<HorizontalOrientationComponent>(entity);
         registry.emplace<ItemCarrierComponent>(entity, item_carrier);
         registry.emplace<GiveJumpOnTopDamageComponent>(entity, 1);
+        registry.emplace<TakeExplosionDamageComponent>(entity);
 
         // Initialization order is important in this case - MainDudeComponent must be the last to create.
         MainDudeComponent main_dude(entity);
         registry.emplace<MainDudeComponent>(entity, main_dude);
+
+        HitpointComponent hitpoints(Inventory::instance().get_hearts());
+        hitpoints.add_observer(reinterpret_cast<Observer<DeathEvent> *>(main_dude.get_death_observer()));
+        registry.emplace<HitpointComponent>(entity, hitpoints);
 
         ClimbingComponent climbing;
         climbing.add_observer(reinterpret_cast<Observer<ClimbingEvent> *>(main_dude.get_climbing_observer()));

--- a/src/game-loop/src/prefabs/npc/Bat.cpp
+++ b/src/game-loop/src/prefabs/npc/Bat.cpp
@@ -1,5 +1,4 @@
 #include "prefabs/npc/Bat.hpp"
-#include "prefabs/particles/BloodParticle.hpp"
 #include "other/ParticleGenerator.hpp"
 
 #include "components/specialized/MainDudeComponent.hpp"
@@ -16,6 +15,7 @@
 #include "components/damage/TakeProjectileDamageComponent.hpp"
 #include "components/damage/TakeMeleeDamageComponent.hpp"
 #include "components/damage/GiveNpcTouchDamageComponent.hpp"
+#include "components/damage/TakeExplosionDamageComponent.hpp"
 
 #include "audio/Audio.hpp"
 #include "EntityRegistry.hpp"
@@ -228,6 +228,7 @@ entt::entity prefabs::Bat::create(float pos_x_center, float pos_y_center)
     registry.emplace<TakeJumpOnTopDamageComponent>(entity);
     registry.emplace<NpcTypeComponent>(entity, NpcType::BAT);
     registry.emplace<GiveNpcTouchDamageComponent>(entity);
+    registry.emplace<TakeExplosionDamageComponent>(entity);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/npc/Caveman.cpp
+++ b/src/game-loop/src/prefabs/npc/Caveman.cpp
@@ -15,6 +15,7 @@
 #include "components/damage/TakeMeleeDamageComponent.hpp"
 #include "components/damage/TakeJumpOnTopDamage.hpp"
 #include "components/damage/GiveNpcTouchDamageComponent.hpp"
+#include "components/damage/TakeExplosionDamageComponent.hpp"
 
 #include "EntityRegistry.hpp"
 #include "TextureType.hpp"
@@ -178,6 +179,7 @@ entt::entity prefabs::Caveman::create(float pos_x_center, float pos_y_center)
     registry.emplace<TakeJumpOnTopDamageComponent>(entity);
     registry.emplace<NpcTypeComponent>(entity, NpcType::CAVEMAN);
     registry.emplace<GiveNpcTouchDamageComponent>(entity);
+    registry.emplace<TakeExplosionDamageComponent>(entity);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/npc/Skeleton.cpp
+++ b/src/game-loop/src/prefabs/npc/Skeleton.cpp
@@ -17,6 +17,7 @@
 #include "components/damage/TakeMeleeDamageComponent.hpp"
 #include "components/damage/TakeJumpOnTopDamage.hpp"
 #include "components/damage/GiveNpcTouchDamageComponent.hpp"
+#include "components/damage/TakeExplosionDamageComponent.hpp"
 
 #include "EntityRegistry.hpp"
 #include "TextureType.hpp"
@@ -185,6 +186,7 @@ entt::entity prefabs::Skeleton::create(float pos_x_center, float pos_y_center)
     registry.emplace<TakeJumpOnTopDamageComponent>(entity);
     registry.emplace<NpcTypeComponent>(entity, NpcType::SKELETON);
     registry.emplace<GiveNpcTouchDamageComponent>(entity);
+    registry.emplace<TakeExplosionDamageComponent>(entity);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/npc/Snake.cpp
+++ b/src/game-loop/src/prefabs/npc/Snake.cpp
@@ -15,6 +15,7 @@
 #include "components/damage/TakeMeleeDamageComponent.hpp"
 #include "components/damage/TakeJumpOnTopDamage.hpp"
 #include "components/damage/GiveNpcTouchDamageComponent.hpp"
+#include "components/damage/TakeExplosionDamageComponent.hpp"
 
 #include "EntityRegistry.hpp"
 #include "TextureType.hpp"
@@ -179,6 +180,7 @@ entt::entity prefabs::Snake::create(float pos_x_center, float pos_y_center)
     registry.emplace<TakeJumpOnTopDamageComponent>(entity);
     registry.emplace<NpcTypeComponent>(entity, NpcType::SNAKE);
     registry.emplace<GiveNpcTouchDamageComponent>(entity);
+    registry.emplace<TakeExplosionDamageComponent>(entity);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/npc/Spider.cpp
+++ b/src/game-loop/src/prefabs/npc/Spider.cpp
@@ -16,6 +16,7 @@
 #include "components/damage/TakeMeleeDamageComponent.hpp"
 #include "components/damage/TakeJumpOnTopDamage.hpp"
 #include "components/damage/GiveNpcTouchDamageComponent.hpp"
+#include "components/damage/TakeExplosionDamageComponent.hpp"
 
 #include "EntityRegistry.hpp"
 #include "TextureType.hpp"
@@ -205,6 +206,7 @@ entt::entity prefabs::Spider::create(float pos_x_center, float pos_y_center, boo
     registry.emplace<TakeJumpOnTopDamageComponent>(entity);
     registry.emplace<NpcTypeComponent>(entity, NpcType::SPIDER);
     registry.emplace<GiveNpcTouchDamageComponent>(entity);
+    registry.emplace<TakeExplosionDamageComponent>(entity);
 
     if (triggered)
     {

--- a/src/game-loop/src/system/DamageSystem.cpp
+++ b/src/game-loop/src/system/DamageSystem.cpp
@@ -1,6 +1,6 @@
 #include "system/DamageSystem.hpp"
-
-#include "components/specialized/MainDudeComponent.hpp"
+#include "EntityRegistry.hpp"
+#include "audio/Audio.hpp"
 #include "components/damage/TakeFallDamageComponent.hpp"
 #include "components/generic/PhysicsComponent.hpp"
 #include "components/generic/NpcTypeComponent.hpp"
@@ -18,9 +18,7 @@
 #include "components/damage/GiveExplosionDamageComponent.hpp"
 #include "components/damage/TakeExplosionDamageComponent.hpp"
 
-#include "EntityRegistry.hpp"
-#include "audio/Audio.hpp"
-#include "other/Inventory.hpp"
+#include <cmath>
 
 namespace
 {
@@ -295,8 +293,8 @@ void DamageSystem::update_explosion_damage()
                 float x_direction = give_damage_position.x_center - body_position.x_center;
                 float y_direction = give_damage_position.y_center - body_position.y_center;
 
-                const float x_velocity = -std::copysign(0.1f, x_direction);
-                const float y_velocity = -std::copysign(0.1f, y_direction);
+                const float x_velocity = -copysign(0.1f, x_direction);
+                const float y_velocity = -copysign(0.1f, y_direction);
 
                 body_physics.set_x_velocity(x_velocity);
                 body_physics.set_y_velocity(y_velocity);


### PR DESCRIPTION
Changes:

* Explosions now give damage to each entity that has `TakeExplosionDamageComponent`
* Introduced `ZoneComponent` existing of width/height
* Each entity within the zone that has at least physics/position components will be moved away out of explosion (direction-wise)
* Main dude gets `ParticleEmitterComponent` attached upon death by explosion (so to emit flame particles)