### PR TITLE
Main dude now takes projectile damage

### DIFF
--- a/src/game-loop/include/components/damage/GiveProjectileDamageComponent.hpp
+++ b/src/game-loop/include/components/damage/GiveProjectileDamageComponent.hpp
@@ -8,8 +8,10 @@ using ProjectileDamage_t = int;
 class GiveProjectileDamageComponent : public Subject<MutualDamage_t>
 {
 public:
-    explicit GiveProjectileDamageComponent(ProjectileDamage_t damage_given)
+
+    explicit GiveProjectileDamageComponent(ProjectileDamage_t damage_given, entt::entity last_throw_source = entt::null)
         : _damage_given(damage_given)
+        , _last_throw_source(last_throw_source)
     {}
 
     void set_mutual(bool mutual)
@@ -27,7 +29,18 @@ public:
         return _damage_given;
     }
 
+    bool is_last_throw_source(entt::entity last_throw_source) const
+    {
+        return last_throw_source == _last_throw_source;
+    }
+
+    void set_last_throw_source(entt::entity last_throw_source)
+    {
+        _last_throw_source = last_throw_source;
+    }
+
 private:
     ProjectileDamage_t _damage_given = 0;
+    entt::entity _last_throw_source;
     bool _mutual = false;
 };

--- a/src/game-loop/include/components/damage/HitpointComponent.hpp
+++ b/src/game-loop/include/components/damage/HitpointComponent.hpp
@@ -13,7 +13,11 @@ using Hitpoint_t = int;
 class HitpointComponent : public Subject<DeathEvent>
 {
 public:
-    explicit HitpointComponent(Hitpoint_t hitpoints) : _hitpoints(hitpoints) {}
+    explicit HitpointComponent(Hitpoint_t hitpoints, bool dispose_when_zero)
+        : _hitpoints(hitpoints)
+        , _dispose_when_zero(dispose_when_zero)
+    {}
+
     HitpointComponent() = default;
 
     void remove_hitpoints(Hitpoint_t hitpoints)
@@ -26,6 +30,9 @@ public:
         return _hitpoints;
     }
 
+    bool is_disposed_when_zero() const { return _dispose_when_zero; }
+
 private:
     Hitpoint_t _hitpoints = 0;
+    bool _dispose_when_zero = false;
 };

--- a/src/game-loop/include/components/specialized/MainDudeComponent.hpp
+++ b/src/game-loop/include/components/specialized/MainDudeComponent.hpp
@@ -77,6 +77,11 @@ public:
         return _explosion_observer.get();
     }
 
+    MainDudeProjectileDamageObserver* get_projectile_damage_observer()
+    {
+        return _projectile_observer.get();
+    }
+
 private:
 
     void enter_if_different(MainDudeBaseState*);
@@ -137,6 +142,7 @@ private:
     std::shared_ptr<MainDudeDeathObserver> _death_observer;
     std::shared_ptr<MainDudeNpcDamageObserver> _npc_damage_observer;
     std::shared_ptr<MainDudeExplosionDamageObserver> _explosion_observer;
+    std::shared_ptr<MainDudeProjectileDamageObserver> _projectile_observer;
 
     static constexpr float DEFAULT_DELTA_X = 0.01f;
     static constexpr float DEFAULT_MAX_X_VELOCITY = 0.050f;

--- a/src/game-loop/include/main-dude/MainDudeObservers.hpp
+++ b/src/game-loop/include/main-dude/MainDudeObservers.hpp
@@ -6,6 +6,7 @@
 #include "components/generic/AnimationComponent.hpp"
 #include "components/generic/ClimbingComponent.hpp"
 #include "components/damage/TakeFallDamageComponent.hpp"
+#include "components/damage/TakeProjectileDamageComponent.hpp"
 #include "components/damage/TakeNpcTouchDamageComponent.hpp"
 #include "components/damage/TakeExplosionDamageComponent.hpp"
 #include "components/damage/HitpointComponent.hpp"
@@ -53,6 +54,15 @@ class MainDudeExplosionDamageObserver : Observer<ExplosionDamageTakenEvent>
 public:
     explicit MainDudeExplosionDamageObserver(entt::entity main_dude) : _main_dude(main_dude) {};
     void on_notify(const ExplosionDamageTakenEvent * event) override;
+private:
+    const entt::entity _main_dude;
+};
+
+class MainDudeProjectileDamageObserver : Observer<ProjectileDamage_t>
+{
+public:
+    explicit MainDudeProjectileDamageObserver(entt::entity main_dude) : _main_dude(main_dude) {};
+    void on_notify(const ProjectileDamage_t * event) override;
 private:
     const entt::entity _main_dude;
 };

--- a/src/game-loop/include/prefabs/items/Arrow.hpp
+++ b/src/game-loop/include/prefabs/items/Arrow.hpp
@@ -6,8 +6,7 @@ namespace prefabs
 {
     struct Arrow
     {
-        static entt::entity create(float pos_x_center, float pos_y_center, entt::entity throw_source);
-        static entt::entity create(float pos_x_center, float pos_y_center);
+        static entt::entity create(float pos_x_center, float pos_y_center, entt::entity throw_source = entt::null);
         static entt::entity create();
     };
 }

--- a/src/game-loop/include/prefabs/items/Arrow.hpp
+++ b/src/game-loop/include/prefabs/items/Arrow.hpp
@@ -6,6 +6,7 @@ namespace prefabs
 {
     struct Arrow
     {
+        static entt::entity create(float pos_x_center, float pos_y_center, entt::entity throw_source);
         static entt::entity create(float pos_x_center, float pos_y_center);
         static entt::entity create();
     };

--- a/src/game-loop/include/prefabs/other/Bullet.hpp
+++ b/src/game-loop/include/prefabs/other/Bullet.hpp
@@ -6,7 +6,7 @@ namespace prefabs
 {
     struct Bullet
     {
-        static entt::entity create(float pos_x_center, float pos_y_center);
+        static entt::entity create(float pos_x_center, float pos_y_center, entt::entity projectile_source = entt::null);
         static entt::entity create();
     };
 }

--- a/src/game-loop/src/components/generic/ItemCarrierComponent.cpp
+++ b/src/game-loop/src/components/generic/ItemCarrierComponent.cpp
@@ -1,4 +1,5 @@
 #include "components/generic/ItemCarrierComponent.hpp"
+#include "components/damage/GiveProjectileDamageComponent.hpp"
 
 #include <cassert>
 #include <cmath>
@@ -82,6 +83,12 @@ void ItemCarrierComponent::put_down_active_item()
     auto& item = registry.get<ItemComponent>(_slots.active_item);
     auto& physics = registry.get<PhysicsComponent>(_slots.active_item);
 
+    if (registry.has<GiveProjectileDamageComponent>(_slots.active_item))
+    {
+        auto& projectile_damage_component = registry.get<GiveProjectileDamageComponent>(_slots.active_item);
+        projectile_damage_component.set_last_throw_source(item.get_item_carrier_entity());
+    }
+
     item.reset_carrier();
     physics.enable_gravity();
 
@@ -98,6 +105,12 @@ void ItemCarrierComponent::throw_active_item(HorizontalOrientationComponent carr
 
     auto& item = registry.get<ItemComponent>(_slots.active_item);
     auto& physics = registry.get<PhysicsComponent>(_slots.active_item);
+
+    if (registry.has<GiveProjectileDamageComponent>(_slots.active_item))
+    {
+        auto& projectile_damage_component = registry.get<GiveProjectileDamageComponent>(_slots.active_item);
+        projectile_damage_component.set_last_throw_source(item.get_item_carrier_entity());
+    }
 
     item.reset_carrier();
     physics.enable_gravity();

--- a/src/game-loop/src/components/specialized/DeathOverlayComponent.cpp
+++ b/src/game-loop/src/components/specialized/DeathOverlayComponent.cpp
@@ -71,7 +71,7 @@ void DeathOverlayComponent::update()
     }
 
     const auto& input = Input::instance();
-    if (input.jumping().value())
+    if (input.jumping().value() && input.jumping().changed())
     {
         _scores_requested = true;
     }

--- a/src/game-loop/src/main-dude/MainDudeComponent.cpp
+++ b/src/game-loop/src/main-dude/MainDudeComponent.cpp
@@ -39,6 +39,7 @@ MainDudeComponent::MainDudeComponent(entt::entity owner) : _owner(owner)
     _death_observer = std::make_shared<MainDudeDeathObserver>(owner);
     _npc_damage_observer = std::make_shared<MainDudeNpcDamageObserver>(owner);
     _explosion_observer = std::make_shared<MainDudeExplosionDamageObserver>(owner);
+    _projectile_observer = std::make_shared<MainDudeProjectileDamageObserver>(owner);
 }
 
 MainDudeComponent::MainDudeComponent(const MainDudeComponent& other) : _owner(other._owner)
@@ -49,6 +50,7 @@ MainDudeComponent::MainDudeComponent(const MainDudeComponent& other) : _owner(ot
     _death_observer = other._death_observer;
     _npc_damage_observer = other._npc_damage_observer;
     _explosion_observer = other._explosion_observer;
+    _projectile_observer = other._projectile_observer;
 }
 
 void MainDudeComponent::update(uint32_t delta_time_ms)

--- a/src/game-loop/src/main-dude/MainDudeObservers.cpp
+++ b/src/game-loop/src/main-dude/MainDudeObservers.cpp
@@ -39,7 +39,6 @@ void MainDudeProjectileDamageObserver::on_notify(const ProjectileDamage_t *event
             .quantity(4)
             .finalize();
 
-    // FIXME: Not sure if stunned in original game, verify this
     main_dude_component.enter_stunned_state();
 }
 

--- a/src/game-loop/src/main-dude/MainDudeObservers.cpp
+++ b/src/game-loop/src/main-dude/MainDudeObservers.cpp
@@ -5,6 +5,7 @@
 #include "components/generic/ParticleEmitterComponent.hpp"
 #include "EntityRegistry.hpp"
 #include "other/Inventory.hpp"
+#include "other/ParticleGenerator.hpp"
 
 void MainDudeClimbingObserver::on_notify(const ClimbingEvent *event)
 {
@@ -22,6 +23,24 @@ void MainDudeClimbingObserver::on_notify(const ClimbingEvent *event)
             break;
         }
     }
+}
+
+void MainDudeProjectileDamageObserver::on_notify(const ProjectileDamage_t *event)
+{
+    auto& registry = EntityRegistry::instance().get_registry();
+    auto& main_dude_component = registry.get<MainDudeComponent>(_main_dude);
+    auto& position = registry.get<PositionComponent>(_main_dude);
+
+    Inventory::instance().remove_hearts(*event);
+
+    ParticleGenerator().particle_type(ParticleType::BLOOD)
+            .position(position.x_center, position.y_center)
+            .max_velocity(0.25f, 0.25f)
+            .quantity(4)
+            .finalize();
+
+    // FIXME: Not sure if stunned in original game, verify this
+    main_dude_component.enter_stunned_state();
 }
 
 void MainDudeExplosionDamageObserver::on_notify(const ExplosionDamageTakenEvent *event)
@@ -72,9 +91,16 @@ void MainDudeDeathObserver::on_notify(const DeathEvent *event)
 {
     auto& registry = EntityRegistry::instance().get_registry();
     auto& main_dude_component = registry.get<MainDudeComponent>(_main_dude);
+    auto& position = registry.get<PositionComponent>(_main_dude);
 
     main_dude_component.notify(MainDudeEvent::DIED);
     main_dude_component.enter_dead_state();
+
+    ParticleGenerator().particle_type(ParticleType::BLOOD)
+            .position(position.x_center, position.y_center)
+            .max_velocity(0.25f, 0.25f)
+            .quantity(4)
+            .finalize();
 }
 
 void MainDudeFallObserver::on_notify(const FallDamage_t *event)

--- a/src/game-loop/src/prefabs/items/Arrow.cpp
+++ b/src/game-loop/src/prefabs/items/Arrow.cpp
@@ -98,11 +98,6 @@ entt::entity prefabs::Arrow::create()
     return create(0, 0);
 }
 
-entt::entity prefabs::Arrow::create(float pos_x_center, float pos_y_center)
-{
-    return create(pos_x_center, pos_y_center, entt::null);
-}
-
 entt::entity prefabs::Arrow::create(float pos_x_center, float pos_y_center, entt::entity throw_source)
 {
     auto& registry = EntityRegistry::instance().get_registry();

--- a/src/game-loop/src/prefabs/items/Arrow.cpp
+++ b/src/game-loop/src/prefabs/items/Arrow.cpp
@@ -100,6 +100,11 @@ entt::entity prefabs::Arrow::create()
 
 entt::entity prefabs::Arrow::create(float pos_x_center, float pos_y_center)
 {
+    return create(pos_x_center, pos_y_center, entt::null);
+}
+
+entt::entity prefabs::Arrow::create(float pos_x_center, float pos_y_center, entt::entity throw_source)
+{
     auto& registry = EntityRegistry::instance().get_registry();
 
     const auto entity = registry.create();
@@ -120,7 +125,7 @@ entt::entity prefabs::Arrow::create(float pos_x_center, float pos_y_center)
     auto arrow_script = std::make_shared<ArrowScript>(entity);
     ScriptingComponent script(arrow_script);
 
-    GiveProjectileDamageComponent give_projectile_damage(2);
+    GiveProjectileDamageComponent give_projectile_damage(2, throw_source);
     give_projectile_damage.set_mutual(true);
     give_projectile_damage.add_observer(reinterpret_cast<Observer<MutualDamage_t>*>(arrow_script->get_observer()));
 
@@ -135,3 +140,4 @@ entt::entity prefabs::Arrow::create(float pos_x_center, float pos_y_center)
 
     return entity;
 }
+

--- a/src/game-loop/src/prefabs/items/Jar.cpp
+++ b/src/game-loop/src/prefabs/items/Jar.cpp
@@ -147,7 +147,7 @@ entt::entity prefabs::Jar::create(float pos_x_center, float pos_y_center)
     GiveProjectileDamageComponent give_projectile_damage(2);
     give_projectile_damage.set_mutual(true);
 
-    HitpointComponent hitpoints(1);
+    HitpointComponent hitpoints(1, true);
     hitpoints.add_observer(reinterpret_cast<Observer<DeathEvent>*>(jar_script->get_observer()));
 
     float critical_speed_x = 0.1f;

--- a/src/game-loop/src/prefabs/items/Pistol.cpp
+++ b/src/game-loop/src/prefabs/items/Pistol.cpp
@@ -43,7 +43,7 @@ namespace
                 Audio::instance().play(SFXType::SHOTGUN);
 
                 _cooldown_timer_ms = 0;
-                auto bullet = prefabs::Bullet::create(position.x_center, position.y_center);
+                auto bullet = prefabs::Bullet::create(position.x_center, position.y_center, item.get_item_carrier_entity());
                 auto& bullet_physics = registry.get<PhysicsComponent>(bullet);
 
                 float offset = 0;

--- a/src/game-loop/src/prefabs/items/Shotgun.cpp
+++ b/src/game-loop/src/prefabs/items/Shotgun.cpp
@@ -55,19 +55,19 @@ namespace
                 }
 
                 {
-                    auto bullet = prefabs::Bullet::create(position.x_center + (bullet_x_pos_offset * 0.33f), position.y_center);
+                    auto bullet = prefabs::Bullet::create(position.x_center + (bullet_x_pos_offset * 0.33f), position.y_center, item.get_item_carrier_entity());
                     auto& bullet_physics = registry.get<PhysicsComponent>(bullet);
                     bullet_physics.set_velocity(bullet_velocity_x, bullet_velocity_y);
                 }
 
                 {
-                    auto bullet = prefabs::Bullet::create(position.x_center + (bullet_x_pos_offset * 0.66f), position.y_center);
+                    auto bullet = prefabs::Bullet::create(position.x_center + (bullet_x_pos_offset * 0.66f), position.y_center, item.get_item_carrier_entity());
                     auto& bullet_physics = registry.get<PhysicsComponent>(bullet);
                     bullet_physics.set_velocity(bullet_velocity_x, bullet_velocity_y + 0.015f);
                 }
 
                 {
-                    auto bullet = prefabs::Bullet::create(position.x_center + (bullet_x_pos_offset * 1.00f), position.y_center);
+                    auto bullet = prefabs::Bullet::create(position.x_center + (bullet_x_pos_offset * 1.00f), position.y_center, item.get_item_carrier_entity());
                     auto& bullet_physics = registry.get<PhysicsComponent>(bullet);
                     bullet_physics.set_velocity(bullet_velocity_x, bullet_velocity_y - 0.015f);
                 }

--- a/src/game-loop/src/prefabs/items/Skull.cpp
+++ b/src/game-loop/src/prefabs/items/Skull.cpp
@@ -101,7 +101,7 @@ entt::entity prefabs::Skull::create(float pos_x_center, float pos_y_center)
     auto skull_script = std::make_shared<SkullScript>(entity);
     ScriptingComponent script(skull_script);
 
-    HitpointComponent hitpoints(1);
+    HitpointComponent hitpoints(1, true);
     hitpoints.add_observer(reinterpret_cast<Observer<DeathEvent>*>(skull_script->get_observer()));
 
     GiveProjectileDamageComponent give_projectile_damage(1);

--- a/src/game-loop/src/prefabs/main-dude/MainDude.cpp
+++ b/src/game-loop/src/prefabs/main-dude/MainDude.cpp
@@ -63,18 +63,6 @@ namespace prefabs
         registry.emplace<ItemCarrierComponent>(entity, item_carrier);
         registry.emplace<GiveJumpOnTopDamageComponent>(entity, 1);
 
-        // FIXME: How to differentiate between projectiles that the main dude has just thrown,
-        //        and the ones from outside, i.e from arrow trap?
-        //
-        //        a) add offset immediately after throwing a projectile so there would be no collision
-        //        b) when checking collisions, ignore projectiles moving away?
-        //        c) give a high velocity treshold?
-        //        d) carry some indicator (i.e component) that would store source of projectile (i.e arrow trop, main dude, nothing)
-        //
-        //        b) save entity id of thrown projectile and ignore it when checking collision
-        //        c) short cooldown just after throwing something?
-
-        // Initialization order is important in this case - MainDudeComponent must be the last to create.
         MainDudeComponent main_dude(entity);
         registry.emplace<MainDudeComponent>(entity, main_dude);
 

--- a/src/game-loop/src/prefabs/main-dude/MainDude.cpp
+++ b/src/game-loop/src/prefabs/main-dude/MainDude.cpp
@@ -66,7 +66,7 @@ namespace prefabs
         MainDudeComponent main_dude(entity);
         registry.emplace<MainDudeComponent>(entity, main_dude);
 
-        HitpointComponent hitpoints(Inventory::instance().get_hearts());
+        HitpointComponent hitpoints(Inventory::instance().get_hearts(), false);
         hitpoints.add_observer(reinterpret_cast<Observer<DeathEvent> *>(main_dude.get_death_observer()));
         registry.emplace<HitpointComponent>(entity, hitpoints);
 

--- a/src/game-loop/src/prefabs/main-dude/MainDude.cpp
+++ b/src/game-loop/src/prefabs/main-dude/MainDude.cpp
@@ -16,6 +16,7 @@
 #include "components/damage/GiveJumpOnTopDamage.hpp"
 #include "components/damage/TakeExplosionDamageComponent.hpp"
 #include "components/damage/TakeFallDamageComponent.hpp"
+#include "components/damage/TakeProjectileDamageComponent.hpp"
 #include "components/specialized/MainDudeComponent.hpp"
 
 #include "EntityRegistry.hpp"
@@ -62,6 +63,17 @@ namespace prefabs
         registry.emplace<ItemCarrierComponent>(entity, item_carrier);
         registry.emplace<GiveJumpOnTopDamageComponent>(entity, 1);
 
+        // FIXME: How to differentiate between projectiles that the main dude has just thrown,
+        //        and the ones from outside, i.e from arrow trap?
+        //
+        //        a) add offset immediately after throwing a projectile so there would be no collision
+        //        b) when checking collisions, ignore projectiles moving away?
+        //        c) give a high velocity treshold?
+        //        d) carry some indicator (i.e component) that would store source of projectile (i.e arrow trop, main dude, nothing)
+        //
+        //        b) save entity id of thrown projectile and ignore it when checking collision
+        //        c) short cooldown just after throwing something?
+
         // Initialization order is important in this case - MainDudeComponent must be the last to create.
         MainDudeComponent main_dude(entity);
         registry.emplace<MainDudeComponent>(entity, main_dude);
@@ -85,6 +97,10 @@ namespace prefabs
         TakeExplosionDamageComponent take_explosion_damage;
         take_explosion_damage.add_observer(reinterpret_cast<Observer<ExplosionDamageTakenEvent> *>(main_dude.get_explosion_damage_observer()));
         registry.emplace<TakeExplosionDamageComponent>(entity, take_explosion_damage);
+
+        TakeProjectileDamageComponent take_projectile_damage;
+        take_projectile_damage.add_observer(reinterpret_cast<Observer<ProjectileDamage_t> *>(main_dude.get_projectile_damage_observer()));
+        registry.emplace<TakeProjectileDamageComponent>(entity, take_projectile_damage);
 
         {
             auto& carrier = registry.get<ItemCarrierComponent>(entity);

--- a/src/game-loop/src/prefabs/npc/Bat.cpp
+++ b/src/game-loop/src/prefabs/npc/Bat.cpp
@@ -212,7 +212,7 @@ entt::entity prefabs::Bat::create(float pos_x_center, float pos_y_center)
     auto bat_script = std::make_shared<BatScript>(entity);
     ScriptingComponent script(bat_script);
 
-    HitpointComponent hitpoints(1);
+    HitpointComponent hitpoints(1, true);
     hitpoints.add_observer(reinterpret_cast<Observer<DeathEvent>*>(bat_script->get_observer()));
 
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);

--- a/src/game-loop/src/prefabs/npc/Caveman.cpp
+++ b/src/game-loop/src/prefabs/npc/Caveman.cpp
@@ -163,7 +163,7 @@ entt::entity prefabs::Caveman::create(float pos_x_center, float pos_y_center)
     auto caveman_script = std::make_shared<CavemanScript>(entity);
     ScriptingComponent script(caveman_script);
 
-    HitpointComponent hitpoints(1);
+    HitpointComponent hitpoints(1, true);
     hitpoints.add_observer(reinterpret_cast<Observer<DeathEvent>*>(caveman_script->get_observer()));
 
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);

--- a/src/game-loop/src/prefabs/npc/Skeleton.cpp
+++ b/src/game-loop/src/prefabs/npc/Skeleton.cpp
@@ -169,7 +169,7 @@ entt::entity prefabs::Skeleton::create(float pos_x_center, float pos_y_center)
     auto skeleton_script = std::make_shared<SkeletonScript>(entity);
     ScriptingComponent script(skeleton_script);
 
-    HitpointComponent hitpoints(1);
+    HitpointComponent hitpoints(1, true);
     hitpoints.add_observer(reinterpret_cast<Observer<DeathEvent>*>(skeleton_script->get_observer()));
 
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);

--- a/src/game-loop/src/prefabs/npc/Snake.cpp
+++ b/src/game-loop/src/prefabs/npc/Snake.cpp
@@ -164,7 +164,7 @@ entt::entity prefabs::Snake::create(float pos_x_center, float pos_y_center)
     auto snake_script = std::make_shared<SnakeScript>(entity);
     ScriptingComponent script(snake_script);
 
-    HitpointComponent hitpoints(1);
+    HitpointComponent hitpoints(1, true);
     hitpoints.add_observer(reinterpret_cast<Observer<DeathEvent>*>(snake_script->get_observer()));
 
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);

--- a/src/game-loop/src/prefabs/npc/Spider.cpp
+++ b/src/game-loop/src/prefabs/npc/Spider.cpp
@@ -190,7 +190,7 @@ entt::entity prefabs::Spider::create(float pos_x_center, float pos_y_center, boo
     auto spider_script = std::make_shared<SpiderScript>(entity);
     ScriptingComponent script(spider_script);
 
-    HitpointComponent hitpoints(1);
+    HitpointComponent hitpoints(1, true);
     hitpoints.add_observer(reinterpret_cast<Observer<DeathEvent>*>(spider_script->get_observer()));
 
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);

--- a/src/game-loop/src/prefabs/other/Bullet.cpp
+++ b/src/game-loop/src/prefabs/other/Bullet.cpp
@@ -58,7 +58,7 @@ entt::entity prefabs::Bullet::create()
     return create(0, 0);
 }
 
-entt::entity prefabs::Bullet::create(float pos_x_center, float pos_y_center)
+entt::entity prefabs::Bullet::create(float pos_x_center, float pos_y_center, entt::entity projectile_source)
 {
     auto& registry = EntityRegistry::instance().get_registry();
 
@@ -81,10 +81,10 @@ entt::entity prefabs::Bullet::create(float pos_x_center, float pos_y_center)
     auto bullet_script = std::make_shared<BulletScript>(entity);
     ScriptingComponent script(bullet_script);
 
-    HitpointComponent hitpoints(1);
+    HitpointComponent hitpoints(1, true);
     hitpoints.add_observer(reinterpret_cast<Observer<DeathEvent>*>(bullet_script->get_observer()));
 
-    GiveProjectileDamageComponent give_projectile_damage(2);
+    GiveProjectileDamageComponent give_projectile_damage(2, projectile_source);
     give_projectile_damage.set_mutual(true);
 
     float critical_speed_x = 0.1f;

--- a/src/game-loop/src/prefabs/traps/ArrowTrap.cpp
+++ b/src/game-loop/src/prefabs/traps/ArrowTrap.cpp
@@ -115,6 +115,7 @@ entt::entity prefabs::ArrowTrap::create(float pos_x_center, float pos_y_center, 
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<PhysicsComponent>(entity, physics);
     registry.emplace<ScriptingComponent>(entity, std::make_shared<ArrowTrapScript>(orientation));
+    // TODO: HitpointComponent + TakeExplosionDamageComponent
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/traps/ArrowTrap.cpp
+++ b/src/game-loop/src/prefabs/traps/ArrowTrap.cpp
@@ -74,7 +74,7 @@ namespace
                     Audio::instance().play(SFXType::ARROW_TRAP);
                     triggered = true;
 
-                    auto arrow = prefabs::Arrow::create(arrow_trap_position.x_center, arrow_trap_position.y_center);
+                    auto arrow = prefabs::Arrow::create(arrow_trap_position.x_center, arrow_trap_position.y_center, owner);
                     auto& arrow_physics = registry.get<PhysicsComponent>(arrow);
                     auto& arrow_position = registry.get<PositionComponent>(arrow);
                     switch (_orientation)

--- a/src/game-loop/src/system/DamageSystem.cpp
+++ b/src/game-loop/src/system/DamageSystem.cpp
@@ -36,10 +36,7 @@ namespace
         {
             hitpoints.notify({npc_type});
 
-            // FIXME: This workaround breaks jars/bullets/skull behavior, as they are neither NPC's nor main dude
-            //        - some flag indicating that entity can be removed after reaching 0 hitpoints?
-
-            if (registry.has<NpcTypeComponent>(entity))
+            if (hitpoints.is_disposed_when_zero())
             {
                 registry.destroy(entity);
             }

--- a/src/game-loop/src/system/DamageSystem.cpp
+++ b/src/game-loop/src/system/DamageSystem.cpp
@@ -35,7 +35,12 @@ namespace
         if (hitpoints.get_hitpoints() <= 0)
         {
             hitpoints.notify({npc_type});
-            registry.destroy(entity);
+
+            // FIXME: This workaround breaks jars/bullets/skull behavior, as they are neither NPC's nor main dude
+            if (registry.has<NpcTypeComponent>(entity))
+            {
+                registry.destroy(entity);
+            }
         }
     }
 }
@@ -110,6 +115,11 @@ void DamageSystem::update_projectile_damage()
                 return;
             }
 
+            if (give_damage.is_last_throw_source(take_damage_entity))
+            {
+                return;
+            }
+
             if (!body_physics.is_collision(projectile_physics, projectile_position, body_position))
             {
                 return;
@@ -128,6 +138,11 @@ void DamageSystem::update_projectile_damage()
 
             if (give_damage.is_mutual())
             {
+                // Set same horizontal direction as projectile:
+                body_physics.set_x_velocity(0.5f * projectile_physics.get_x_velocity());
+                // Make it point slightly upwards:
+                body_physics.set_y_velocity(-0.1f);
+
                 if (registry.has<HitpointComponent>(give_damage_entity))
                 {
                     remove_hitpoints(damage, give_damage_entity);

--- a/src/game-loop/src/system/DamageSystem.cpp
+++ b/src/game-loop/src/system/DamageSystem.cpp
@@ -37,6 +37,8 @@ namespace
             hitpoints.notify({npc_type});
 
             // FIXME: This workaround breaks jars/bullets/skull behavior, as they are neither NPC's nor main dude
+            //        - some flag indicating that entity can be removed after reaching 0 hitpoints?
+
             if (registry.has<NpcTypeComponent>(entity))
             {
                 registry.destroy(entity);
@@ -136,13 +138,13 @@ void DamageSystem::update_projectile_damage()
             remove_hitpoints(damage, take_damage_entity);
             Audio::instance().play(SFXType::HIT);
 
+            // Set same horizontal direction as projectile:
+            body_physics.set_x_velocity(0.5f * projectile_physics.get_x_velocity());
+            // Make it point slightly upwards:
+            body_physics.set_y_velocity(-0.1f);
+
             if (give_damage.is_mutual())
             {
-                // Set same horizontal direction as projectile:
-                body_physics.set_x_velocity(0.5f * projectile_physics.get_x_velocity());
-                // Make it point slightly upwards:
-                body_physics.set_y_velocity(-0.1f);
-
                 if (registry.has<HitpointComponent>(give_damage_entity))
                 {
                     remove_hitpoints(damage, give_damage_entity);


### PR DESCRIPTION
Main dude taking projectile damage causes the following design problem - 

*How to differentiate between projectiles that the main dude has just thrown,
and the ones from outside, i.e from arrow trap?*

Possible solutions:

a) add position offset immediately after throwing a projectile so there would be no collision
b) when checking collisions, ignore projectiles moving away?
c) give a high velocity treshold only after which damage is applied?
d) carry some indicator (i.e component) that would store source of projectile (i.e arrow trop, main dude, nothing)
e) **save entity id of projectile source (i.e main dude if thrown it) and ignore it when checking collision**
f) short cooldown just after throwing something?

So far I decided to stick to e), but it is not definitive.


Changes: 

* Added `_dispose_when_zero` flag to `HitpointComponent` and honoring it in `DamagesSystem`
* Saving entity ID of projectile thrower inside `GiveProjectileDamageComponent`
