### PR TITLE
Disposing arrow-trap entity upon explosion

### DIFF
--- a/src/game-loop/src/prefabs/traps/ArrowTrap.cpp
+++ b/src/game-loop/src/prefabs/traps/ArrowTrap.cpp
@@ -4,11 +4,14 @@
 #include "components/generic/HorizontalOrientationComponent.hpp"
 #include "components/generic/PositionComponent.hpp"
 #include "components/generic/ScriptingComponent.hpp"
+#include "components/damage/TakeExplosionDamageComponent.hpp"
+#include "components/damage/HitpointComponent.hpp"
 #include "components/specialized/MainDudeComponent.hpp"
 
 #include "spritesheet-frames/NPCSpritesheetFrames.hpp"
 #include "EntityRegistry.hpp"
 #include "audio/Audio.hpp"
+#include "Level.hpp"
 
 #include <cmath>
 
@@ -17,10 +20,46 @@ namespace
     constexpr float activation_distance_x = 7;
     constexpr float activation_distance_y = 0.5f;
 
+    class ArrowTrapExplosionObserver : public Observer<ExplosionDamageTakenEvent>
+    {
+    public:
+        explicit ArrowTrapExplosionObserver(entt::entity owner) : _owner(owner)
+        {
+        }
+
+        void on_notify(const ExplosionDamageTakenEvent* event) override
+        {
+            auto &registry = EntityRegistry::instance().get_registry();
+
+            // Check if arrow-trap tile was destroyed to confirm entity can be disposed:
+            auto &tile_batch = Level::instance().get_tile_batch();
+            auto &position = registry.get<PositionComponent>(_owner);
+
+            auto *arrow_trap_tile = tile_batch.map_tiles[static_cast<int>(position.x_center)][static_cast<int>(position.y_center)];
+
+            if (arrow_trap_tile->map_tile_type != MapTileType::ARROW_TRAP_LEFT &&
+                arrow_trap_tile->map_tile_type != MapTileType::ARROW_TRAP_RIGHT)
+            {
+                // Can be disposed:
+                registry.destroy(_owner);
+            }
+        }
+    private:
+        entt::entity _owner;
+    };
+
     class ArrowTrapScript final : public ScriptBase
     {
     public:
-        explicit ArrowTrapScript(HorizontalOrientation orientation) : _orientation(orientation) {}
+        explicit ArrowTrapScript(HorizontalOrientation orientation, entt::entity owner)
+            : _orientation(orientation)
+            , _explosion_observer(owner)
+        {}
+
+        ArrowTrapExplosionObserver* get_explosion_observer()
+        {
+            return &_explosion_observer;
+        }
 
         void update(entt::entity owner, uint32_t delta_time_ms) override
         {
@@ -100,6 +139,7 @@ namespace
 
     private:
         const HorizontalOrientation _orientation;
+        ArrowTrapExplosionObserver _explosion_observer;
     };
 }
 
@@ -112,10 +152,16 @@ entt::entity prefabs::ArrowTrap::create(float pos_x_center, float pos_y_center, 
     PhysicsComponent physics(1.0f, 1.0f);
     physics.disable_gravity();
 
+    auto arrow_trap_script = std::make_shared<ArrowTrapScript>(orientation, entity);
+
+    TakeExplosionDamageComponent explosion_component;
+    explosion_component.add_observer(reinterpret_cast<Observer<ExplosionDamageTakenEvent>*>(arrow_trap_script->get_explosion_observer()));
+
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<PhysicsComponent>(entity, physics);
-    registry.emplace<ScriptingComponent>(entity, std::make_shared<ArrowTrapScript>(orientation));
-    // TODO: HitpointComponent + TakeExplosionDamageComponent
+    registry.emplace<ScriptingComponent>(entity, arrow_trap_script);
+    registry.emplace<HitpointComponent>(entity, 1, false);
+    registry.emplace<TakeExplosionDamageComponent>(entity, explosion_component);
 
     return entity;
 }

--- a/src/game-loop/src/system/DamageSystem.cpp
+++ b/src/game-loop/src/system/DamageSystem.cpp
@@ -302,18 +302,8 @@ void DamageSystem::update_explosion_damage()
                     auto& take_damage_hitpoints = registry.get<HitpointComponent>(body_entity);
                     auto& take_damage_explosion = registry.get<TakeExplosionDamageComponent>(body_entity);
 
-                    take_damage_hitpoints.remove_hitpoints(take_damage_hitpoints.get_hitpoints() + 1);
-                    take_damage_hitpoints.notify({});
+                    remove_hitpoints(take_damage_hitpoints.get_hitpoints(), body_entity);
                     take_damage_explosion.notify({});
-
-                    // Only remove if it was an NPC:
-                    if (registry.has<NpcTypeComponent>(body_entity))
-                    {
-                        // FIXME: What if it is i.e caveman? Cavemen don't disappear upon death - should implement a
-                        //        cleanup method that would be called in the end of DamageSystem update method, plus
-                        //        additional flag indicating that entity can be disposed.
-                        registry.destroy(body_entity);
-                    }
                 }
             }
         });


### PR DESCRIPTION
Untill now, only arrow-trap tile was removed upon explosion - meaning that arrow was still spawned there when trap triggered (although the trap was invisible at this point).