### PR TITLE
Spikes taking explosion damage

### DIFF
--- a/src/game-loop/CMakeLists.txt
+++ b/src/game-loop/CMakeLists.txt
@@ -109,6 +109,8 @@ add_library(GameLoop STATIC
         include/components/damage/TakeJumpOnTopDamage.hpp
         include/components/damage/GiveExplosionDamageComponent.hpp
         include/components/damage/TakeExplosionDamageComponent.hpp
+        include/components/damage/GiveSpikesDamageComponent.hpp
+        include/components/damage/TakeSpikesDamageComponent.hpp
 
         # Prefabs:
 

--- a/src/game-loop/include/components/damage/GiveSpikesDamageComponent.hpp
+++ b/src/game-loop/include/components/damage/GiveSpikesDamageComponent.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+struct GiveSpikesDamageComponent
+{
+    // Spikes cause instant death - no damage parameter
+    // TODO: Treshold speed?
+
+    // https://github.com/skypjack/entt/issues/330
+    char dummy_member_for_entt;
+};

--- a/src/game-loop/include/components/damage/GiveSpikesDamageComponent.hpp
+++ b/src/game-loop/include/components/damage/GiveSpikesDamageComponent.hpp
@@ -2,9 +2,6 @@
 
 struct GiveSpikesDamageComponent
 {
-    // Spikes cause instant death - no damage parameter
-    // TODO: Treshold speed?
-
     // https://github.com/skypjack/entt/issues/330
     char dummy_member_for_entt;
 };

--- a/src/game-loop/include/components/damage/TakeSpikesDamageComponent.hpp
+++ b/src/game-loop/include/components/damage/TakeSpikesDamageComponent.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "patterns/Subject.hpp"
+
+struct SpikesDamageEvent
+{};
+
+struct TakeSpikesDamageComponent : public Subject<SpikesDamageEvent>
+{
+    // https://github.com/skypjack/entt/issues/330
+    char dummy_member_for_entt;
+};

--- a/src/game-loop/include/components/specialized/MainDudeComponent.hpp
+++ b/src/game-loop/include/components/specialized/MainDudeComponent.hpp
@@ -82,6 +82,11 @@ public:
         return _projectile_observer.get();
     }
 
+    MainDudeSpikesDamageObserver* get_spikes_damage_observer()
+    {
+        return _spikes_observer.get();
+    }
+
 private:
 
     void enter_if_different(MainDudeBaseState*);
@@ -143,6 +148,7 @@ private:
     std::shared_ptr<MainDudeNpcDamageObserver> _npc_damage_observer;
     std::shared_ptr<MainDudeExplosionDamageObserver> _explosion_observer;
     std::shared_ptr<MainDudeProjectileDamageObserver> _projectile_observer;
+    std::shared_ptr<MainDudeSpikesDamageObserver> _spikes_observer;
 
     static constexpr float DEFAULT_DELTA_X = 0.01f;
     static constexpr float DEFAULT_MAX_X_VELOCITY = 0.050f;

--- a/src/game-loop/include/main-dude/MainDudeObservers.hpp
+++ b/src/game-loop/include/main-dude/MainDudeObservers.hpp
@@ -9,6 +9,7 @@
 #include "components/damage/TakeProjectileDamageComponent.hpp"
 #include "components/damage/TakeNpcTouchDamageComponent.hpp"
 #include "components/damage/TakeExplosionDamageComponent.hpp"
+#include "components/damage/TakeSpikesDamageComponent.hpp"
 #include "components/damage/HitpointComponent.hpp"
 
 class MainDudeClimbingObserver : Observer<ClimbingEvent>
@@ -63,6 +64,15 @@ class MainDudeProjectileDamageObserver : Observer<ProjectileDamage_t>
 public:
     explicit MainDudeProjectileDamageObserver(entt::entity main_dude) : _main_dude(main_dude) {};
     void on_notify(const ProjectileDamage_t * event) override;
+private:
+    const entt::entity _main_dude;
+};
+
+class MainDudeSpikesDamageObserver : Observer<SpikesDamageEvent>
+{
+public:
+    explicit MainDudeSpikesDamageObserver(entt::entity main_dude) : _main_dude(main_dude) {};
+    void on_notify(const SpikesDamageEvent * event) override;
 private:
     const entt::entity _main_dude;
 };

--- a/src/game-loop/include/system/DamageSystem.hpp
+++ b/src/game-loop/include/system/DamageSystem.hpp
@@ -14,4 +14,5 @@ private:
     static void update_jump_on_top_damage();
     static void update_npc_touch_damage(std::uint32_t delta_time_ms);
     static void update_explosion_damage();
+    static void update_spikes_damage();
 };

--- a/src/game-loop/src/main-dude/MainDudeComponent.cpp
+++ b/src/game-loop/src/main-dude/MainDudeComponent.cpp
@@ -40,6 +40,7 @@ MainDudeComponent::MainDudeComponent(entt::entity owner) : _owner(owner)
     _npc_damage_observer = std::make_shared<MainDudeNpcDamageObserver>(owner);
     _explosion_observer = std::make_shared<MainDudeExplosionDamageObserver>(owner);
     _projectile_observer = std::make_shared<MainDudeProjectileDamageObserver>(owner);
+    _spikes_observer = std::make_shared<MainDudeSpikesDamageObserver>(owner);
 }
 
 MainDudeComponent::MainDudeComponent(const MainDudeComponent& other) : _owner(other._owner)
@@ -51,6 +52,7 @@ MainDudeComponent::MainDudeComponent(const MainDudeComponent& other) : _owner(ot
     _npc_damage_observer = other._npc_damage_observer;
     _explosion_observer = other._explosion_observer;
     _projectile_observer = other._projectile_observer;
+    _spikes_observer = other._spikes_observer;
 }
 
 void MainDudeComponent::update(uint32_t delta_time_ms)

--- a/src/game-loop/src/main-dude/MainDudeObservers.cpp
+++ b/src/game-loop/src/main-dude/MainDudeObservers.cpp
@@ -42,6 +42,14 @@ void MainDudeProjectileDamageObserver::on_notify(const ProjectileDamage_t *event
     main_dude_component.enter_stunned_state();
 }
 
+void MainDudeSpikesDamageObserver::on_notify(const SpikesDamageEvent *event)
+{
+    auto& registry = EntityRegistry::instance().get_registry();
+    auto& hitpoints = registry.get<HitpointComponent>(_main_dude);
+
+    Inventory::instance().remove_hearts(hitpoints.get_hitpoints());
+}
+
 void MainDudeExplosionDamageObserver::on_notify(const ExplosionDamageTakenEvent *event)
 {
     auto& registry = EntityRegistry::instance().get_registry();

--- a/src/game-loop/src/prefabs/main-dude/MainDude.cpp
+++ b/src/game-loop/src/prefabs/main-dude/MainDude.cpp
@@ -17,6 +17,7 @@
 #include "components/damage/TakeExplosionDamageComponent.hpp"
 #include "components/damage/TakeFallDamageComponent.hpp"
 #include "components/damage/TakeProjectileDamageComponent.hpp"
+#include "components/damage/TakeSpikesDamageComponent.hpp"
 #include "components/specialized/MainDudeComponent.hpp"
 
 #include "EntityRegistry.hpp"
@@ -89,6 +90,10 @@ namespace prefabs
         TakeProjectileDamageComponent take_projectile_damage;
         take_projectile_damage.add_observer(reinterpret_cast<Observer<ProjectileDamage_t> *>(main_dude.get_projectile_damage_observer()));
         registry.emplace<TakeProjectileDamageComponent>(entity, take_projectile_damage);
+
+        TakeSpikesDamageComponent take_spikes_damage;
+        take_spikes_damage.add_observer(reinterpret_cast<Observer<SpikesDamageEvent> *>(main_dude.get_spikes_damage_observer()));
+        registry.emplace<TakeSpikesDamageComponent>(entity, take_spikes_damage);
 
         {
             auto& carrier = registry.get<ItemCarrierComponent>(entity);

--- a/src/game-loop/src/prefabs/npc/Caveman.cpp
+++ b/src/game-loop/src/prefabs/npc/Caveman.cpp
@@ -16,6 +16,7 @@
 #include "components/damage/TakeJumpOnTopDamage.hpp"
 #include "components/damage/GiveNpcTouchDamageComponent.hpp"
 #include "components/damage/TakeExplosionDamageComponent.hpp"
+#include "components/damage/TakeSpikesDamageComponent.hpp"
 
 #include "EntityRegistry.hpp"
 #include "TextureType.hpp"
@@ -180,6 +181,7 @@ entt::entity prefabs::Caveman::create(float pos_x_center, float pos_y_center)
     registry.emplace<NpcTypeComponent>(entity, NpcType::CAVEMAN);
     registry.emplace<GiveNpcTouchDamageComponent>(entity);
     registry.emplace<TakeExplosionDamageComponent>(entity);
+    registry.emplace<TakeSpikesDamageComponent>(entity);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/npc/Snake.cpp
+++ b/src/game-loop/src/prefabs/npc/Snake.cpp
@@ -16,6 +16,7 @@
 #include "components/damage/TakeJumpOnTopDamage.hpp"
 #include "components/damage/GiveNpcTouchDamageComponent.hpp"
 #include "components/damage/TakeExplosionDamageComponent.hpp"
+#include "components/damage/TakeSpikesDamageComponent.hpp"
 
 #include "EntityRegistry.hpp"
 #include "TextureType.hpp"
@@ -181,6 +182,7 @@ entt::entity prefabs::Snake::create(float pos_x_center, float pos_y_center)
     registry.emplace<NpcTypeComponent>(entity, NpcType::SNAKE);
     registry.emplace<GiveNpcTouchDamageComponent>(entity);
     registry.emplace<TakeExplosionDamageComponent>(entity);
+    registry.emplace<TakeSpikesDamageComponent>(entity);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/npc/Spider.cpp
+++ b/src/game-loop/src/prefabs/npc/Spider.cpp
@@ -17,6 +17,7 @@
 #include "components/damage/TakeJumpOnTopDamage.hpp"
 #include "components/damage/GiveNpcTouchDamageComponent.hpp"
 #include "components/damage/TakeExplosionDamageComponent.hpp"
+#include "components/damage/TakeSpikesDamageComponent.hpp"
 
 #include "EntityRegistry.hpp"
 #include "TextureType.hpp"
@@ -207,6 +208,7 @@ entt::entity prefabs::Spider::create(float pos_x_center, float pos_y_center, boo
     registry.emplace<NpcTypeComponent>(entity, NpcType::SPIDER);
     registry.emplace<GiveNpcTouchDamageComponent>(entity);
     registry.emplace<TakeExplosionDamageComponent>(entity);
+    registry.emplace<TakeSpikesDamageComponent>(entity);
 
     if (triggered)
     {

--- a/src/game-loop/src/prefabs/traps/Spikes.cpp
+++ b/src/game-loop/src/prefabs/traps/Spikes.cpp
@@ -8,6 +8,7 @@
 #include "components/generic/MeshComponent.hpp"
 #include "components/damage/TakeExplosionDamageComponent.hpp"
 #include "components/damage/HitpointComponent.hpp"
+#include "components/damage/GiveSpikesDamageComponent.hpp"
 
 #include "EntityRegistry.hpp"
 #include "TextureType.hpp"
@@ -58,13 +59,7 @@ entt::entity prefabs::Spikes::create(float pos_x_center, float pos_y_center)
     registry.emplace<ScriptingComponent>(entity, std::make_shared<SpikesScript>());
     registry.emplace<HitpointComponent>(entity, 1, true);
     registry.emplace<TakeExplosionDamageComponent>(entity);
-
-    // TODO: Spikes should take explosion damage (but without arrow-trap's checking for tile, only hitpoint component)
-    //       ^ DONE
-
-    // TODO: Spikes should give melee damage to every entity that collides with it AND has positive vertical speed (some treshold?)
-    //       New kind of component? [Give/Take]SpikeDamageComponent?
-    //       Threshold speed could make cape item save from killing by spikes - like in the original game
+    registry.emplace<GiveSpikesDamageComponent>(entity);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/traps/Spikes.cpp
+++ b/src/game-loop/src/prefabs/traps/Spikes.cpp
@@ -6,6 +6,8 @@
 #include "components/generic/ScriptingComponent.hpp"
 #include "components/generic/QuadComponent.hpp"
 #include "components/generic/MeshComponent.hpp"
+#include "components/damage/TakeExplosionDamageComponent.hpp"
+#include "components/damage/HitpointComponent.hpp"
 
 #include "EntityRegistry.hpp"
 #include "TextureType.hpp"
@@ -54,6 +56,15 @@ entt::entity prefabs::Spikes::create(float pos_x_center, float pos_y_center)
     registry.emplace<PhysicsComponent>(entity, physics);
     registry.emplace<HorizontalOrientationComponent>(entity);
     registry.emplace<ScriptingComponent>(entity, std::make_shared<SpikesScript>());
+    registry.emplace<HitpointComponent>(entity, 1, true);
+    registry.emplace<TakeExplosionDamageComponent>(entity);
+
+    // TODO: Spikes should take explosion damage (but without arrow-trap's checking for tile, only hitpoint component)
+    //       ^ DONE
+
+    // TODO: Spikes should give melee damage to every entity that collides with it AND has positive vertical speed (some treshold?)
+    //       New kind of component? [Give/Take]SpikeDamageComponent?
+    //       Threshold speed could make cape item save from killing by spikes - like in the original game
 
     return entity;
 }


### PR DESCRIPTION
Changes:

* Bomb explosions destroy spikes
* New components - `TakeSpikesDamageComponent`, `GiveSpikesDamageComponent`, updated in `DamageSystem`
* Main dude, caveman, spider, snake can be now killed by spikes
* Spike kill after reaching treshold vertical speed + overlaping with other body