### PR TITLE
Extended RenderingLayer with new layers

### DIFF
--- a/src/game-loop/include/components/generic/MeshComponent.hpp
+++ b/src/game-loop/include/components/generic/MeshComponent.hpp
@@ -20,6 +20,6 @@ struct MeshComponent
     IndexType* indices = nullptr;
     std::size_t indices_count = 0;
     TextureID texture_id = 0;
-    RenderingLayer rendering_layer = RenderingLayer::LAYER_4_PROPS;
+    RenderingLayer rendering_layer = RenderingLayer::LAYER_5_PROPS;
     CameraType camera_type = CameraType::SCREEN_SPACE;
 };

--- a/src/game-loop/include/components/generic/TextComponent.hpp
+++ b/src/game-loop/include/components/generic/TextComponent.hpp
@@ -15,6 +15,7 @@ public:
     void set_text(const std::string& text) { _properties.text = text; _dirty = true; }
     void set_yellow(bool yellow) { _properties.yellow = yellow; _dirty = true; }
     void set_scale(float scale) { _properties.scale = scale; _dirty = true; }
+    void set_layer(RenderingLayer layer) { _properties.layer = layer; _dirty = true; };
 
     WorldUnit_t get_font_width() const { return 0.5f * _properties.scale; }
     WorldUnit_t get_font_height() const { return 0.5f * _properties.scale; }
@@ -31,6 +32,7 @@ private:
         bool yellow = false;
         float scale = 1.0f;
         std::string text;
+        RenderingLayer layer = RenderingLayer::LAYER_2_HUD;
     } _properties;
 
     std::vector<Vertex> _mesh;

--- a/src/game-loop/src/components/generic/TextComponent.cpp
+++ b/src/game-loop/src/components/generic/TextComponent.cpp
@@ -55,7 +55,7 @@ void TextComponent::update(entt::entity owner)
     mesh_component.indices = _indices.data();
     mesh_component.indices_count = _indices.size();
     mesh_component.texture_id = TextureBank::instance().get_texture(TextureType::FONT);
-    mesh_component.rendering_layer = RenderingLayer::LAYER_1_UI_TEXT;
+    mesh_component.rendering_layer = _properties.layer;
     mesh_component.camera_type = CameraType::SCREEN_SPACE;
 
     _dirty = false;

--- a/src/game-loop/src/components/specialized/PauseOverlayComponent.cpp
+++ b/src/game-loop/src/components/specialized/PauseOverlayComponent.cpp
@@ -42,7 +42,7 @@ void PauseOverlayComponent::update(entt::registry& registry)
                                         _viewport->get_height_world_units());
                 MeshComponent mesh;
 
-                mesh.rendering_layer = RenderingLayer::LAYER_2_ITEMS;
+                mesh.rendering_layer = RenderingLayer::LAYER_1_OVERLAY;
                 mesh.camera_type = CameraType::SCREEN_SPACE;
                 quad.frame_changed<HUDSpritesheetFrames>(HUDSpritesheetFrames::HALF_OPAQUE_TILE);
 
@@ -59,6 +59,7 @@ void PauseOverlayComponent::update(entt::registry& registry)
                 PositionComponent position;
                 MeshComponent mesh;
 
+                text_pause.set_layer(RenderingLayer::LAYER_0_OVERLAY_TEXT);
                 text_pause.set_scale(2.0f);
                 text_pause.set_text(PAUSED_MSG);
                 position.x_center = (_viewport->get_width_world_units() / 2.0f) -
@@ -82,6 +83,7 @@ void PauseOverlayComponent::update(entt::registry& registry)
 
                 const std::string available_controls = get_available_controls_msg();
 
+                text_controls.set_layer(RenderingLayer::LAYER_0_OVERLAY_TEXT);
                 text_controls.set_text(available_controls);
                 position.x_center = (_viewport->get_width_world_units() / 2.0f) -
                                     (text_controls.get_width() / 2.0f) +

--- a/src/game-loop/src/prefabs/collectibles/BigGem.cpp
+++ b/src/game-loop/src/prefabs/collectibles/BigGem.cpp
@@ -33,7 +33,7 @@ entt::entity prefabs::BigGem::create(float pos_x_center, float pos_y_center)
     std::uint16_t frame_index = static_cast<std::uint16_t>(CollectiblesSpritesheetFrames::DIAMOND_BIG) + std::rand() % 3;
     
     quad.frame_changed(static_cast<CollectiblesSpritesheetFrames>(frame_index));
-    mesh.rendering_layer = RenderingLayer::LAYER_4_PROPS;
+    mesh.rendering_layer = RenderingLayer::LAYER_5_PROPS;
     mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
 
     registry.emplace<PositionComponent>(entity, position);

--- a/src/game-loop/src/prefabs/collectibles/GoldChunk.cpp
+++ b/src/game-loop/src/prefabs/collectibles/GoldChunk.cpp
@@ -31,7 +31,7 @@ entt::entity prefabs::GoldChunk::create(float pos_x_center, float pos_y_center)
     CollectibleComponent collectible(100, LootCollectedEvent::GOLD_CHUNK);
 
     quad.frame_changed(CollectiblesSpritesheetFrames::GOLD_CHUNK);
-    mesh.rendering_layer = RenderingLayer::LAYER_4_PROPS;
+    mesh.rendering_layer = RenderingLayer::LAYER_5_PROPS;
     mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
 
     registry.emplace<PositionComponent>(entity, position);

--- a/src/game-loop/src/prefabs/collectibles/GoldNugget.cpp
+++ b/src/game-loop/src/prefabs/collectibles/GoldNugget.cpp
@@ -31,7 +31,7 @@ entt::entity prefabs::GoldNugget::create(float pos_x_center, float pos_y_center)
     CollectibleComponent collectible(500, LootCollectedEvent::GOLD_NUGGET);
 
     quad.frame_changed(CollectiblesSpritesheetFrames::GOLD_NUGGET);
-    mesh.rendering_layer = RenderingLayer::LAYER_4_PROPS;
+    mesh.rendering_layer = RenderingLayer::LAYER_5_PROPS;
     mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
 
     registry.emplace<PositionComponent>(entity, position);

--- a/src/game-loop/src/prefabs/collectibles/SingleGoldBar.cpp
+++ b/src/game-loop/src/prefabs/collectibles/SingleGoldBar.cpp
@@ -31,7 +31,7 @@ entt::entity prefabs::SingleGoldBar::create(float pos_x_center, float pos_y_cent
     CollectibleComponent collectible(500, LootCollectedEvent::SINGLE_GOLD_BAR);
 
     quad.frame_changed(CollectiblesSpritesheetFrames::SINGLE_GOLD_BAR);
-    mesh.rendering_layer = RenderingLayer::LAYER_4_PROPS;
+    mesh.rendering_layer = RenderingLayer::LAYER_5_PROPS;
     mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
 
     registry.emplace<PositionComponent>(entity, position);

--- a/src/game-loop/src/prefabs/collectibles/SmallGem.cpp
+++ b/src/game-loop/src/prefabs/collectibles/SmallGem.cpp
@@ -33,7 +33,7 @@ entt::entity prefabs::SmallGem::create(float pos_x_center, float pos_y_center)
     std::uint16_t frame_index = static_cast<std::uint16_t>(CollectiblesSpritesheetFrames::DIAMOND_SMALL) + std::rand() % 3;
 
     quad.frame_changed(static_cast<CollectiblesSpritesheetFrames>(frame_index));
-    mesh.rendering_layer = RenderingLayer::LAYER_4_PROPS;
+    mesh.rendering_layer = RenderingLayer::LAYER_5_PROPS;
     mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
 
     registry.emplace<PositionComponent>(entity, position);

--- a/src/game-loop/src/prefabs/collectibles/TripleGoldBar.cpp
+++ b/src/game-loop/src/prefabs/collectibles/TripleGoldBar.cpp
@@ -31,7 +31,7 @@ entt::entity prefabs::TripleGoldBar::create(float pos_x_center, float pos_y_cent
     CollectibleComponent collectible(1000, LootCollectedEvent::TRIPLE_GOLD_BAR);
 
     quad.frame_changed(CollectiblesSpritesheetFrames::TRIPLE_GOLD_BAR);
-    mesh.rendering_layer = RenderingLayer::LAYER_4_PROPS;
+    mesh.rendering_layer = RenderingLayer::LAYER_5_PROPS;
     mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
 
     registry.emplace<PositionComponent>(entity, position);

--- a/src/game-loop/src/prefabs/effects/Explosion.cpp
+++ b/src/game-loop/src/prefabs/effects/Explosion.cpp
@@ -37,7 +37,7 @@ entt::entity prefabs::Explosion::create(float pos_x_center, float pos_y_center)
                     static_cast<std::size_t>(CollectiblesSpritesheetFrames::EXPLOSION_9_LAST),
                     40, false);
 
-    mesh.rendering_layer = RenderingLayer::LAYER_2_ITEMS;
+    mesh.rendering_layer = RenderingLayer::LAYER_3_ITEMS;
     mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
 
     registry.emplace<PositionComponent>(entity, position);

--- a/src/game-loop/src/prefabs/effects/ShotgunBlast.cpp
+++ b/src/game-loop/src/prefabs/effects/ShotgunBlast.cpp
@@ -33,7 +33,7 @@ entt::entity prefabs::ShotgunBlast::create(float pos_x_center, float pos_y_cente
                     static_cast<std::size_t>(CollectiblesSpritesheetFrames::SHOTGUN_BLAST_9_LAST),
                     40, false);
 
-    mesh.rendering_layer = RenderingLayer::LAYER_2_ITEMS;
+    mesh.rendering_layer = RenderingLayer::LAYER_3_ITEMS;
     mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
 
     registry.emplace<PositionComponent>(entity, position);

--- a/src/game-loop/src/prefabs/items/Arrow.cpp
+++ b/src/game-loop/src/prefabs/items/Arrow.cpp
@@ -126,7 +126,7 @@ entt::entity prefabs::Arrow::create(float pos_x_center, float pos_y_center, entt
 
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<QuadComponent>(entity, quad);
-    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_2_ITEMS, CameraType::MODEL_VIEW_SPACE);
+    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_3_ITEMS, CameraType::MODEL_VIEW_SPACE);
     registry.emplace<PhysicsComponent>(entity, physics);
     registry.emplace<ItemComponent>(entity, item);
     registry.emplace<ScriptingComponent>(entity, script);

--- a/src/game-loop/src/prefabs/items/Bomb.cpp
+++ b/src/game-loop/src/prefabs/items/Bomb.cpp
@@ -175,7 +175,7 @@ entt::entity prefabs::Bomb::create(float pos_x_center, float pos_y_center)
 
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<QuadComponent>(entity, quad);
-    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_2_ITEMS, CameraType::MODEL_VIEW_SPACE);
+    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_3_ITEMS, CameraType::MODEL_VIEW_SPACE);
     registry.emplace<PhysicsComponent>(entity, physics);
     registry.emplace<ItemComponent>(entity, item);
     registry.emplace<ScriptingComponent>(entity, std::make_shared<BombScript>());

--- a/src/game-loop/src/prefabs/items/Cape.cpp
+++ b/src/game-loop/src/prefabs/items/Cape.cpp
@@ -108,7 +108,7 @@ entt::entity prefabs::Cape::create(float pos_x_center, float pos_y_center)
 
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<QuadComponent>(entity, quad);
-    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_4_PROPS, CameraType::MODEL_VIEW_SPACE);
+    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_5_PROPS, CameraType::MODEL_VIEW_SPACE);
     registry.emplace<PhysicsComponent>(entity, physics);
     registry.emplace<ItemComponent>(entity, item);
     registry.emplace<ScriptingComponent>(entity, std::make_shared<CapeScript>());

--- a/src/game-loop/src/prefabs/items/Chest.cpp
+++ b/src/game-loop/src/prefabs/items/Chest.cpp
@@ -91,7 +91,7 @@ entt::entity prefabs::Chest::create(float pos_x_center, float pos_y_center)
 
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<QuadComponent>(entity, quad);
-    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_2_ITEMS, CameraType::MODEL_VIEW_SPACE);
+    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_3_ITEMS, CameraType::MODEL_VIEW_SPACE);
     registry.emplace<PhysicsComponent>(entity, physics);
     registry.emplace<ItemComponent>(entity, item);
     registry.emplace<ScriptingComponent>(entity, std::make_shared<ChestScript>());

--- a/src/game-loop/src/prefabs/items/Crate.cpp
+++ b/src/game-loop/src/prefabs/items/Crate.cpp
@@ -142,7 +142,7 @@ entt::entity prefabs::Crate::create(float pos_x_center, float pos_y_center)
 
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<QuadComponent>(entity, quad);
-    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_2_ITEMS, CameraType::MODEL_VIEW_SPACE);
+    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_3_ITEMS, CameraType::MODEL_VIEW_SPACE);
     registry.emplace<PhysicsComponent>(entity, physics);
     registry.emplace<ItemComponent>(entity, item);
     registry.emplace<ScriptingComponent>(entity, std::make_shared<CrateScript>());

--- a/src/game-loop/src/prefabs/items/Jar.cpp
+++ b/src/game-loop/src/prefabs/items/Jar.cpp
@@ -156,7 +156,7 @@ entt::entity prefabs::Jar::create(float pos_x_center, float pos_y_center)
 
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<QuadComponent>(entity, quad);
-    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_2_ITEMS, CameraType::MODEL_VIEW_SPACE);
+    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_3_ITEMS, CameraType::MODEL_VIEW_SPACE);
     registry.emplace<PhysicsComponent>(entity, physics);
     registry.emplace<ItemComponent>(entity, item);
     registry.emplace<ScriptingComponent>(entity, jar_script);

--- a/src/game-loop/src/prefabs/items/Jetpack.cpp
+++ b/src/game-loop/src/prefabs/items/Jetpack.cpp
@@ -109,7 +109,7 @@ entt::entity prefabs::Jetpack::create(float pos_x_center, float pos_y_center)
 
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<QuadComponent>(entity, quad);
-    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_4_PROPS, CameraType::MODEL_VIEW_SPACE);
+    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_5_PROPS, CameraType::MODEL_VIEW_SPACE);
     registry.emplace<PhysicsComponent>(entity, physics);
     registry.emplace<ItemComponent>(entity, item);
     registry.emplace<ScriptingComponent>(entity, std::make_shared<JetpackScript>());

--- a/src/game-loop/src/prefabs/items/Pistol.cpp
+++ b/src/game-loop/src/prefabs/items/Pistol.cpp
@@ -92,7 +92,7 @@ entt::entity prefabs::Pistol::create(float pos_x_center, float pos_y_center)
 
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<QuadComponent>(entity, quad);
-    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_2_ITEMS, CameraType::MODEL_VIEW_SPACE);
+    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_3_ITEMS, CameraType::MODEL_VIEW_SPACE);
     registry.emplace<PhysicsComponent>(entity, physics);
     registry.emplace<ItemComponent>(entity, item);
     registry.emplace<ScriptingComponent>(entity, std::make_shared<PistolScript>());

--- a/src/game-loop/src/prefabs/items/Rock.cpp
+++ b/src/game-loop/src/prefabs/items/Rock.cpp
@@ -38,7 +38,7 @@ entt::entity prefabs::Rock::create(float pos_x_center, float pos_y_center)
 
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<QuadComponent>(entity, quad);
-    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_2_ITEMS, CameraType::MODEL_VIEW_SPACE);
+    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_3_ITEMS, CameraType::MODEL_VIEW_SPACE);
     registry.emplace<PhysicsComponent>(entity, physics);
     registry.emplace<ItemComponent>(entity, item);
     registry.emplace<HorizontalOrientationComponent>(entity);

--- a/src/game-loop/src/prefabs/items/Rope.cpp
+++ b/src/game-loop/src/prefabs/items/Rope.cpp
@@ -149,7 +149,7 @@ entt::entity prefabs::Rope::create(float pos_x_center, float pos_y_center)
 
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<QuadComponent>(entity, quad);
-    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_2_ITEMS, CameraType::MODEL_VIEW_SPACE);
+    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_3_ITEMS, CameraType::MODEL_VIEW_SPACE);
     registry.emplace<PhysicsComponent>(entity, width, height);
     registry.emplace<ItemComponent>(entity, item);
     registry.emplace<ScriptingComponent>(entity, std::make_shared<RopeScript>(Point2D(pos_x_center, pos_y_center)));

--- a/src/game-loop/src/prefabs/items/RopeChainElement.cpp
+++ b/src/game-loop/src/prefabs/items/RopeChainElement.cpp
@@ -27,7 +27,7 @@ entt::entity prefabs::RopeChainElement::create(float pos_x_center, float pos_y_c
 
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<QuadComponent>(entity, quad);
-    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_2_ITEMS, CameraType::MODEL_VIEW_SPACE);
+    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_3_ITEMS, CameraType::MODEL_VIEW_SPACE);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/items/RopeChainElement.cpp
+++ b/src/game-loop/src/prefabs/items/RopeChainElement.cpp
@@ -27,7 +27,7 @@ entt::entity prefabs::RopeChainElement::create(float pos_x_center, float pos_y_c
 
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<QuadComponent>(entity, quad);
-    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_3_ITEMS, CameraType::MODEL_VIEW_SPACE);
+    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_5_PROPS, CameraType::MODEL_VIEW_SPACE);
 
     return entity;
 }

--- a/src/game-loop/src/prefabs/items/Shotgun.cpp
+++ b/src/game-loop/src/prefabs/items/Shotgun.cpp
@@ -110,7 +110,7 @@ entt::entity prefabs::Shotgun::create(float pos_x_center, float pos_y_center)
 
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<QuadComponent>(entity, quad);
-    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_2_ITEMS, CameraType::MODEL_VIEW_SPACE);
+    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_3_ITEMS, CameraType::MODEL_VIEW_SPACE);
     registry.emplace<PhysicsComponent>(entity, physics);
     registry.emplace<ItemComponent>(entity, item);
     registry.emplace<ScriptingComponent>(entity, std::make_shared<ShotgunScript>());

--- a/src/game-loop/src/prefabs/items/Skull.cpp
+++ b/src/game-loop/src/prefabs/items/Skull.cpp
@@ -114,7 +114,7 @@ entt::entity prefabs::Skull::create(float pos_x_center, float pos_y_center)
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<QuadComponent>(entity, quad);
     registry.emplace<ScriptingComponent>(entity, script);
-    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_2_ITEMS, CameraType::MODEL_VIEW_SPACE);
+    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_3_ITEMS, CameraType::MODEL_VIEW_SPACE);
     registry.emplace<PhysicsComponent>(entity, physics);
     registry.emplace<ItemComponent>(entity, item);
     registry.emplace<HorizontalOrientationComponent>(entity);

--- a/src/game-loop/src/prefabs/items/Whip.cpp
+++ b/src/game-loop/src/prefabs/items/Whip.cpp
@@ -110,7 +110,7 @@ namespace
             auto& registry = EntityRegistry::instance().get_registry();
 
             MeshComponent mesh;
-            mesh.rendering_layer = RenderingLayer::LAYER_2_ITEMS;
+            mesh.rendering_layer = RenderingLayer::LAYER_3_ITEMS;
             mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
 
             QuadComponent quad(TextureType::COLLECTIBLES, width, height);

--- a/src/game-loop/src/prefabs/main-dude/MainDude.cpp
+++ b/src/game-loop/src/prefabs/main-dude/MainDude.cpp
@@ -52,7 +52,7 @@ namespace prefabs
 
         MeshComponent mesh;
         mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
-        mesh.rendering_layer = RenderingLayer::LAYER_3_DUDE;
+        mesh.rendering_layer = RenderingLayer::LAYER_4_DUDE;
 
         registry.emplace<PositionComponent>(entity, position);
         registry.emplace<QuadComponent>(entity, quad);

--- a/src/game-loop/src/prefabs/npc/Bat.cpp
+++ b/src/game-loop/src/prefabs/npc/Bat.cpp
@@ -218,7 +218,7 @@ entt::entity prefabs::Bat::create(float pos_x_center, float pos_y_center)
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<QuadComponent>(entity, quad);
     registry.emplace<AnimationComponent>(entity);
-    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_2_ITEMS, CameraType::MODEL_VIEW_SPACE);
+    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_3_ITEMS, CameraType::MODEL_VIEW_SPACE);
     registry.emplace<PhysicsComponent>(entity, physics);
     registry.emplace<ScriptingComponent>(entity, script);
     registry.emplace<HorizontalOrientationComponent>(entity);

--- a/src/game-loop/src/prefabs/npc/Caveman.cpp
+++ b/src/game-loop/src/prefabs/npc/Caveman.cpp
@@ -170,7 +170,7 @@ entt::entity prefabs::Caveman::create(float pos_x_center, float pos_y_center)
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<QuadComponent>(entity, quad);
     registry.emplace<AnimationComponent>(entity);
-    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_2_ITEMS, CameraType::MODEL_VIEW_SPACE);
+    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_3_ITEMS, CameraType::MODEL_VIEW_SPACE);
     registry.emplace<PhysicsComponent>(entity, width -  (4.0f / 16.0f), height -  (2.0f / 16.0f));
     registry.emplace<ScriptingComponent>(entity, script);
     registry.emplace<HorizontalOrientationComponent>(entity);

--- a/src/game-loop/src/prefabs/npc/Skeleton.cpp
+++ b/src/game-loop/src/prefabs/npc/Skeleton.cpp
@@ -175,7 +175,7 @@ entt::entity prefabs::Skeleton::create(float pos_x_center, float pos_y_center)
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<QuadComponent>(entity, quad);
     registry.emplace<AnimationComponent>(entity);
-    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_2_ITEMS, CameraType::MODEL_VIEW_SPACE);
+    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_3_ITEMS, CameraType::MODEL_VIEW_SPACE);
     registry.emplace<PhysicsComponent>(entity, width - (4.0f / 16.0f), height - (2.0f / 16.0f));
     registry.emplace<ScriptingComponent>(entity, script);
     registry.emplace<HorizontalOrientationComponent>(entity);

--- a/src/game-loop/src/prefabs/npc/Snake.cpp
+++ b/src/game-loop/src/prefabs/npc/Snake.cpp
@@ -171,7 +171,7 @@ entt::entity prefabs::Snake::create(float pos_x_center, float pos_y_center)
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<QuadComponent>(entity, quad);
     registry.emplace<AnimationComponent>(entity);
-    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_2_ITEMS, CameraType::MODEL_VIEW_SPACE);
+    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_3_ITEMS, CameraType::MODEL_VIEW_SPACE);
     registry.emplace<PhysicsComponent>(entity, width - (4.0f / 16.0f), height - (4.0f / 16.0f));
     registry.emplace<ScriptingComponent>(entity, script);
     registry.emplace<HorizontalOrientationComponent>(entity);

--- a/src/game-loop/src/prefabs/npc/Spider.cpp
+++ b/src/game-loop/src/prefabs/npc/Spider.cpp
@@ -197,7 +197,7 @@ entt::entity prefabs::Spider::create(float pos_x_center, float pos_y_center, boo
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);
     registry.emplace<QuadComponent>(entity, quad);
     registry.emplace<AnimationComponent>(entity);
-    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_2_ITEMS, CameraType::MODEL_VIEW_SPACE);
+    registry.emplace<MeshComponent>(entity, RenderingLayer::LAYER_3_ITEMS, CameraType::MODEL_VIEW_SPACE);
     registry.emplace<PhysicsComponent>(entity, physics);
     registry.emplace<ScriptingComponent>(entity, spider_script);
     registry.emplace<HorizontalOrientationComponent>(entity);

--- a/src/game-loop/src/prefabs/other/Bones.cpp
+++ b/src/game-loop/src/prefabs/other/Bones.cpp
@@ -29,7 +29,7 @@ entt::entity prefabs::Bones::create(float pos_x_center, float pos_y_center)
     MeshComponent mesh;
 
     quad.frame_changed(NPCSpritesheetFrames::BONES);
-    mesh.rendering_layer = RenderingLayer::LAYER_3_DUDE;
+    mesh.rendering_layer = RenderingLayer::LAYER_4_DUDE;
     mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
 
     registry.emplace<PositionComponent>(entity, position);

--- a/src/game-loop/src/prefabs/other/Bullet.cpp
+++ b/src/game-loop/src/prefabs/other/Bullet.cpp
@@ -75,7 +75,7 @@ entt::entity prefabs::Bullet::create(float pos_x_center, float pos_y_center, ent
     physics.disable_gravity();
 
     quad.frame_changed(CollectiblesSpritesheetFrames::BULLET);
-    mesh.rendering_layer = RenderingLayer::LAYER_2_ITEMS;
+    mesh.rendering_layer = RenderingLayer::LAYER_3_ITEMS;
     mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
 
     auto bullet_script = std::make_shared<BulletScript>(entity);

--- a/src/game-loop/src/prefabs/particles/BloodParticle.cpp
+++ b/src/game-loop/src/prefabs/particles/BloodParticle.cpp
@@ -39,7 +39,7 @@ entt::entity prefabs::BloodParticle::create(float pos_x_center, float pos_y_cent
                     110, true);
 
     MeshComponent mesh;
-    mesh.rendering_layer = RenderingLayer::LAYER_3_DUDE;
+    mesh.rendering_layer = RenderingLayer::LAYER_4_DUDE;
     mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
 
     ParticleEmitterComponent emitter;

--- a/src/game-loop/src/prefabs/particles/BloodTrailParticle.cpp
+++ b/src/game-loop/src/prefabs/particles/BloodTrailParticle.cpp
@@ -32,7 +32,7 @@ entt::entity prefabs::BloodTrailParticle::create(float pos_x_center, float pos_y
                     static_cast<std::size_t>(CollectiblesSpritesheetFrames::BLOOD_TRAIL_6_LAST),
                     110, false);
 
-    mesh.rendering_layer = RenderingLayer::LAYER_3_DUDE;
+    mesh.rendering_layer = RenderingLayer::LAYER_4_DUDE;
     mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
 
     registry.emplace<PositionComponent>(entity, position);

--- a/src/game-loop/src/prefabs/particles/BombCollectedParticle.cpp
+++ b/src/game-loop/src/prefabs/particles/BombCollectedParticle.cpp
@@ -32,7 +32,7 @@ entt::entity prefabs::BombCollectedParticle::create(float pos_x_center, float po
                     static_cast<std::size_t>(CollectiblesSpritesheetFrames::BOMB_COLLECTED_1_LAST),
                     200, true);
 
-    mesh.rendering_layer = RenderingLayer::LAYER_4_PROPS;
+    mesh.rendering_layer = RenderingLayer::LAYER_5_PROPS;
     mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
 
     registry.emplace<PositionComponent>(entity, position);

--- a/src/game-loop/src/prefabs/particles/BonesParticle.cpp
+++ b/src/game-loop/src/prefabs/particles/BonesParticle.cpp
@@ -59,7 +59,7 @@ entt::entity prefabs::BonesParticle::create(float pos_x_center, float pos_y_cent
                     100, true);
 
     MeshComponent mesh;
-    mesh.rendering_layer = RenderingLayer::LAYER_3_DUDE;
+    mesh.rendering_layer = RenderingLayer::LAYER_4_DUDE;
     mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
 
     registry.emplace<PositionComponent>(entity, pos_x_center, pos_y_center);

--- a/src/game-loop/src/prefabs/particles/FlameParticle.cpp
+++ b/src/game-loop/src/prefabs/particles/FlameParticle.cpp
@@ -72,7 +72,7 @@ entt::entity prefabs::FlameParticle::create(float pos_x_center, float pos_y_cent
 
     quad.frame_changed<CollectiblesSpritesheetFrames>(CollectiblesSpritesheetFrames::FLAME);
 
-    mesh.rendering_layer = RenderingLayer::LAYER_3_DUDE;
+    mesh.rendering_layer = RenderingLayer::LAYER_4_DUDE;
     mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
 
     registry.emplace<PositionComponent>(entity, position);

--- a/src/game-loop/src/prefabs/particles/FlameTrailParticle.cpp
+++ b/src/game-loop/src/prefabs/particles/FlameTrailParticle.cpp
@@ -41,7 +41,7 @@ entt::entity prefabs::FlameTrailParticle::create(float pos_x_center, float pos_y
                     static_cast<std::size_t>(CollectiblesSpritesheetFrames::FLAME_TRAIL_4_LAST),
                     110, false);
 
-    mesh.rendering_layer = RenderingLayer::LAYER_3_DUDE;
+    mesh.rendering_layer = RenderingLayer::LAYER_4_DUDE;
     mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
 
     registry.emplace<PositionComponent>(entity, position);

--- a/src/game-loop/src/prefabs/particles/ItemCollectedParticle.cpp
+++ b/src/game-loop/src/prefabs/particles/ItemCollectedParticle.cpp
@@ -32,7 +32,7 @@ entt::entity prefabs::ItemCollectedParticle::create(float pos_x_center, float po
                     static_cast<std::size_t>(CollectiblesSpritesheetFrames::ITEM_COLLECTED_1_LAST),
                     200, true);
 
-    mesh.rendering_layer = RenderingLayer::LAYER_4_PROPS;
+    mesh.rendering_layer = RenderingLayer::LAYER_5_PROPS;
     mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
 
     registry.emplace<PositionComponent>(entity, position);

--- a/src/game-loop/src/prefabs/particles/PoofParticle.cpp
+++ b/src/game-loop/src/prefabs/particles/PoofParticle.cpp
@@ -39,7 +39,7 @@ entt::entity prefabs::PoofParticle::create(float pos_x_center, float pos_y_cente
 
     quad.frame_changed<CollectiblesSpritesheetFrames>(CollectiblesSpritesheetFrames::POOF_0_FIRST);
 
-    mesh.rendering_layer = RenderingLayer::LAYER_3_DUDE;
+    mesh.rendering_layer = RenderingLayer::LAYER_4_DUDE;
     mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
 
     registry.emplace<PositionComponent>(entity, position);

--- a/src/game-loop/src/prefabs/particles/RopeCollectedParticle.cpp
+++ b/src/game-loop/src/prefabs/particles/RopeCollectedParticle.cpp
@@ -32,7 +32,7 @@ entt::entity prefabs::RopeCollectedParticle::create(float pos_x_center, float po
                     static_cast<std::size_t>(CollectiblesSpritesheetFrames::ROPE_COLLECTED_1_LAST),
                     200, true);
 
-    mesh.rendering_layer = RenderingLayer::LAYER_4_PROPS;
+    mesh.rendering_layer = RenderingLayer::LAYER_5_PROPS;
     mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
 
     registry.emplace<PositionComponent>(entity, position);

--- a/src/game-loop/src/prefabs/particles/RubbleSmallParticle.cpp
+++ b/src/game-loop/src/prefabs/particles/RubbleSmallParticle.cpp
@@ -31,7 +31,7 @@ entt::entity prefabs::RubbleSmallParticle::create(float pos_x_center, float pos_
 
     quad.frame_changed<CollectiblesSpritesheetFrames>(CollectiblesSpritesheetFrames::RUBBLE_SMALL);
 
-    mesh.rendering_layer = RenderingLayer::LAYER_3_DUDE;
+    mesh.rendering_layer = RenderingLayer::LAYER_4_DUDE;
     mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
 
     registry.emplace<PositionComponent>(entity, position);

--- a/src/game-loop/src/prefabs/particles/SmokePuffParticle.cpp
+++ b/src/game-loop/src/prefabs/particles/SmokePuffParticle.cpp
@@ -32,7 +32,7 @@ entt::entity prefabs::SmokePuffParticle::create(float pos_x_center, float pos_y_
                     static_cast<std::size_t>(CollectiblesSpritesheetFrames::SMOKE_PUFF_7_LAST),
                     75, false);
 
-    mesh.rendering_layer = RenderingLayer::LAYER_3_DUDE;
+    mesh.rendering_layer = RenderingLayer::LAYER_4_DUDE;
     mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
 
     registry.emplace<PositionComponent>(entity, position);

--- a/src/game-loop/src/prefabs/props/CopyrightsSign.cpp
+++ b/src/game-loop/src/prefabs/props/CopyrightsSign.cpp
@@ -24,7 +24,7 @@ entt::entity prefabs::CopyrightsSign::create(float pos_x_center, float pos_y_cen
     MeshComponent mesh;
 
     quad.frame_changed(MainMenuSpritesheetFrames::COPYRIGHTS);
-    mesh.rendering_layer = RenderingLayer::LAYER_4_PROPS;
+    mesh.rendering_layer = RenderingLayer::LAYER_5_PROPS;
     mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
 
     registry.emplace<PositionComponent>(entity, position);

--- a/src/game-loop/src/prefabs/props/MainLogo.cpp
+++ b/src/game-loop/src/prefabs/props/MainLogo.cpp
@@ -24,7 +24,7 @@ entt::entity prefabs::MainLogo::create(float pos_x_center, float pos_y_center)
     MeshComponent mesh;
 
     quad.frame_changed(MainMenuSpritesheetFrames::MAIN_LOGO);
-    mesh.rendering_layer = RenderingLayer::LAYER_4_PROPS;
+    mesh.rendering_layer = RenderingLayer::LAYER_5_PROPS;
     mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
 
     registry.emplace<PositionComponent>(entity, position);

--- a/src/game-loop/src/prefabs/props/QuitSign.cpp
+++ b/src/game-loop/src/prefabs/props/QuitSign.cpp
@@ -24,7 +24,7 @@ entt::entity prefabs::QuitSign::create(float pos_x_center, float pos_y_center)
     MeshComponent mesh;
 
     quad.frame_changed(MainMenuSpritesheetFrames::QUIT);
-    mesh.rendering_layer = RenderingLayer::LAYER_4_PROPS;
+    mesh.rendering_layer = RenderingLayer::LAYER_5_PROPS;
     mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
 
     registry.emplace<PositionComponent>(entity, position);

--- a/src/game-loop/src/prefabs/props/ResetSign.cpp
+++ b/src/game-loop/src/prefabs/props/ResetSign.cpp
@@ -24,7 +24,7 @@ entt::entity prefabs::ResetSign::create(float pos_x_center, float pos_y_center)
     MeshComponent mesh;
 
     quad.frame_changed(MainMenuSpritesheetFrames::RESET);
-    mesh.rendering_layer = RenderingLayer::LAYER_4_PROPS;
+    mesh.rendering_layer = RenderingLayer::LAYER_5_PROPS;
     mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
 
     registry.emplace<PositionComponent>(entity, position);

--- a/src/game-loop/src/prefabs/props/ScoresSign.cpp
+++ b/src/game-loop/src/prefabs/props/ScoresSign.cpp
@@ -24,7 +24,7 @@ entt::entity prefabs::ScoresSign::create(float pos_x_center, float pos_y_center)
     MeshComponent mesh;
 
     quad.frame_changed(MainMenuSpritesheetFrames::SCORES);
-    mesh.rendering_layer = RenderingLayer::LAYER_4_PROPS;
+    mesh.rendering_layer = RenderingLayer::LAYER_5_PROPS;
     mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
 
     registry.emplace<PositionComponent>(entity, position);

--- a/src/game-loop/src/prefabs/props/StartSign.cpp
+++ b/src/game-loop/src/prefabs/props/StartSign.cpp
@@ -24,7 +24,7 @@ entt::entity prefabs::StartSign::create(float pos_x_center, float pos_y_center)
     MeshComponent mesh;
 
     quad.frame_changed(MainMenuSpritesheetFrames::START);
-    mesh.rendering_layer = RenderingLayer::LAYER_4_PROPS;
+    mesh.rendering_layer = RenderingLayer::LAYER_5_PROPS;
     mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
 
     registry.emplace<PositionComponent>(entity, position);

--- a/src/game-loop/src/prefabs/props/TutorialSign.cpp
+++ b/src/game-loop/src/prefabs/props/TutorialSign.cpp
@@ -24,7 +24,7 @@ entt::entity prefabs::TutorialSign::create(float pos_x_center, float pos_y_cente
     MeshComponent mesh;
 
     quad.frame_changed(MainMenuSpritesheetFrames::TUTORIAL);
-    mesh.rendering_layer = RenderingLayer::LAYER_4_PROPS;
+    mesh.rendering_layer = RenderingLayer::LAYER_5_PROPS;
     mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
 
     registry.emplace<PositionComponent>(entity, position);

--- a/src/game-loop/src/prefabs/traps/Spikes.cpp
+++ b/src/game-loop/src/prefabs/traps/Spikes.cpp
@@ -48,7 +48,7 @@ entt::entity prefabs::Spikes::create(float pos_x_center, float pos_y_center)
     physics.disable_gravity();
 
     quad.frame_changed(NPCSpritesheetFrames::SPIKES);
-    mesh.rendering_layer = RenderingLayer::LAYER_2_ITEMS;
+    mesh.rendering_layer = RenderingLayer::LAYER_3_ITEMS;
     mesh.camera_type = CameraType::MODEL_VIEW_SPACE;
 
     registry.emplace<PositionComponent>(entity, position);

--- a/src/game-loop/src/prefabs/ui/HudIcon.cpp
+++ b/src/game-loop/src/prefabs/ui/HudIcon.cpp
@@ -18,7 +18,7 @@ entt::entity prefabs::HudIcon::create(float x, float y, HUDSpritesheetFrames fra
     QuadComponent quad(TextureType::HUD, getIconSizeWorldUnits(), getIconSizeWorldUnits());
     MeshComponent mesh;
 
-    mesh.rendering_layer = RenderingLayer::LAYER_2_ITEMS;
+    mesh.rendering_layer = RenderingLayer::LAYER_3_ITEMS;
     mesh.camera_type = CameraType::SCREEN_SPACE;
     quad.frame_changed<HUDSpritesheetFrames>(frame);
 

--- a/src/level/src/TileBatch.cpp
+++ b/src/level/src/TileBatch.cpp
@@ -473,7 +473,7 @@ entt::entity TileBatch::add_render_entity(entt::registry &registry)
     mesh_component.indices = _indices.data();
     mesh_component.indices_count = _indices.size();
     mesh_component.texture_id = TextureBank::instance().get_texture(TextureType::CAVE_LEVEL_TILES);
-    mesh_component.rendering_layer = RenderingLayer::LAYER_5_TILES;
+    mesh_component.rendering_layer = RenderingLayer::LAYER_6_TILES;
     mesh_component.camera_type = CameraType::MODEL_VIEW_SPACE;
 
     registry.emplace<MeshComponent>(entity, mesh_component);

--- a/src/rendering-types/interface/RenderingLayer.hpp
+++ b/src/rendering-types/interface/RenderingLayer.hpp
@@ -4,9 +4,11 @@
 
 enum class RenderingLayer : std::uint16_t
 {
-    LAYER_5_TILES,
-    LAYER_4_PROPS,
-    LAYER_3_DUDE,
-    LAYER_2_ITEMS,
-    LAYER_1_UI_TEXT,
+    LAYER_6_TILES,
+    LAYER_5_PROPS,
+    LAYER_4_DUDE,
+    LAYER_3_ITEMS,
+    LAYER_2_HUD,
+    LAYER_1_OVERLAY,
+    LAYER_0_OVERLAY_TEXT,
 };


### PR DESCRIPTION
Previously, there was not enough layers to cover all cases and HUD (i.e hearts/ropes/bombs/dollars counters) were rendered on the same layer as the pause overlay.