### PR TITLE
Melee/Projectile damage components now hold a vector of recently overlapped bodies

### DIFF
--- a/src/game-loop/include/components/damage/GiveMeleeDamageComponent.hpp
+++ b/src/game-loop/include/components/damage/GiveMeleeDamageComponent.hpp
@@ -2,6 +2,7 @@
 
 #include "patterns/Subject.hpp"
 #include "components/generic/PhysicsComponent.hpp"
+#include <vector>
 
 using MeleeDamage_t = int;
 class GiveMeleeDamageComponent
@@ -16,13 +17,12 @@ public:
         return _damage_given;
     }
 
-    bool cooldown_reached() const { return _cooldown_ms >= TOP_COOLDOWN_MS; }
-    void reset_cooldown() { _cooldown_ms = 0; }
-    void update_cooldown(uint32_t delta_t_ms) { _cooldown_ms += delta_t_ms; }
+    std::vector<entt::entity>& get_last_update_overlaping_bodies()
+    {
+        return _last_update_overlaping_bodies;
+    }
 
 private:
+    std::vector<entt::entity> _last_update_overlaping_bodies;
     MeleeDamage_t _damage_given = 0;
-
-    static const int TOP_COOLDOWN_MS = 1000;
-    int _cooldown_ms = TOP_COOLDOWN_MS;
 };

--- a/src/game-loop/include/components/damage/GiveProjectileDamageComponent.hpp
+++ b/src/game-loop/include/components/damage/GiveProjectileDamageComponent.hpp
@@ -2,6 +2,7 @@
 
 #include "patterns/Subject.hpp"
 #include "components/generic/PhysicsComponent.hpp"
+#include <vector>
 
 using MutualDamage_t = int;
 using ProjectileDamage_t = int;
@@ -44,8 +45,14 @@ public:
         _last_throw_source = last_throw_source;
     }
 
+    std::vector<entt::entity>& get_last_update_overlaping_bodies()
+    {
+        return _last_update_overlaping_bodies;
+    }
+
 private:
     ProjectileDamage_t _damage_given = 0;
     entt::entity _last_throw_source = entt::null;
+    std::vector<entt::entity> _last_update_overlaping_bodies;
     bool _mutual = false;
 };

--- a/src/game-loop/src/game-loop/GameLoopStartedState.cpp
+++ b/src/game-loop/src/game-loop/GameLoopStartedState.cpp
@@ -33,8 +33,8 @@ void GameLoopStartedState::enter(GameLoop& game_loop)
     TextureBank::instance().load_texture_regions();
 
     auto& registry = EntityRegistry::instance().get_registry();
-    registry.reserve<MeshComponent>(256);
-    registry.reserve<QuadComponent>(256);
+    registry.reserve<MeshComponent>(1024);
+    registry.reserve<QuadComponent>(1024);
 
     _game_initialized = true;
 }

--- a/src/game-loop/src/prefabs/npc/CavemanStates.cpp
+++ b/src/game-loop/src/prefabs/npc/CavemanStates.cpp
@@ -10,6 +10,7 @@
 #include "components/damage/TakeJumpOnTopDamage.hpp"
 #include "components/damage/TakeMeleeDamageComponent.hpp"
 #include "components/damage/GiveNpcTouchDamageComponent.hpp"
+#include "components/damage/GiveProjectileDamageComponent.hpp"
 
 #include "spritesheet-frames/NPCSpritesheetFrames.hpp"
 #include "EntityRegistry.hpp"
@@ -176,6 +177,7 @@ namespace prefabs
         if (registry.has<TakeMeleeDamageComponent>(id)) registry.remove<TakeMeleeDamageComponent>(id);
         if (registry.has<TakeJumpOnTopDamageComponent>(id)) registry.remove<TakeJumpOnTopDamageComponent>(id);
         if (registry.has<GiveNpcTouchDamageComponent>(id)) registry.remove<GiveNpcTouchDamageComponent>(id);
+        if (!registry.has<GiveProjectileDamageComponent>(id)) registry.emplace<GiveProjectileDamageComponent>(id, 1);
     }
 
     void CavemanDeadState::exit(CavemanScript& caveman, entt::entity id)

--- a/src/game-loop/src/prefabs/npc/DamselScript.cpp
+++ b/src/game-loop/src/prefabs/npc/DamselScript.cpp
@@ -25,6 +25,7 @@ void prefabs::DamselProjectileDamageObserver::on_notify(const ProjectileDamage_t
 
     auto& scripting_component = registry.get<ScriptingComponent>(_damsel);
     auto* damsel_script = scripting_component.get<prefabs::DamselScript>();
+    damsel_script->set_panic(true);
     damsel_script->enter_state(&damsel_script->_states.stunned, _damsel);
 }
 

--- a/src/game-loop/src/prefabs/npc/DamselStates.cpp
+++ b/src/game-loop/src/prefabs/npc/DamselStates.cpp
@@ -10,6 +10,7 @@
 #include "components/generic/ItemComponent.hpp"
 #include "components/generic/AnimationComponent.hpp"
 #include "components/generic/PhysicsComponent.hpp"
+#include "components/damage/GiveProjectileDamageComponent.hpp"
 #include "components/damage/TakeMeleeDamageComponent.hpp"
 #include "components/damage/TakeExplosionDamageComponent.hpp"
 #include "components/damage/TakeProjectileDamageComponent.hpp"
@@ -371,6 +372,8 @@ namespace prefabs
         physics.set_bounciness(0.4f);
         quad.frame_changed<NPCSpritesheetFrames>(NPCSpritesheetFrames::DAMSEL_DEAD);
         animation.stop();
+
+        if (!registry.has<GiveProjectileDamageComponent>(id)) registry.emplace<GiveProjectileDamageComponent>(id, 1);
     }
 
     void DamselDeadState::exit(DamselScript&, entt::entity id)

--- a/src/game-loop/src/prefabs/npc/Shopkeeper.cpp
+++ b/src/game-loop/src/prefabs/npc/Shopkeeper.cpp
@@ -17,6 +17,7 @@
 #include "components/damage/TakeFallDamageComponent.hpp"
 #include "components/damage/GiveProjectileDamageComponent.hpp"
 #include "components/damage/TakeProjectileDamageComponent.hpp"
+#include "components/damage/TakeSpikesDamageComponent.hpp"
 #include "components/damage/HitpointComponent.hpp"
 #include "components/damage/TakeMeleeDamageComponent.hpp"
 #include "components/damage/TakeJumpOnTopDamage.hpp"
@@ -68,6 +69,7 @@ entt::entity prefabs::Shopkeeper::create(float pos_x_center, float pos_y_center)
     registry.emplace<HorizontalOrientationComponent>(entity);
     registry.emplace<HitpointComponent>(entity, hitpoints);
     registry.emplace<TakeProjectileDamageComponent>(entity, take_projectile_damage);
+    registry.emplace<TakeSpikesDamageComponent>(entity);
     registry.emplace<TakeMeleeDamageComponent>(entity, take_melee_damage);
     registry.emplace<TakeJumpOnTopDamageComponent>(entity, take_jump_on_top_damage);
     registry.emplace<NpcTypeComponent>(entity, NpcType::SHOPKEEPER);

--- a/src/game-loop/src/prefabs/npc/ShopkeeperStates.cpp
+++ b/src/game-loop/src/prefabs/npc/ShopkeeperStates.cpp
@@ -11,6 +11,7 @@
 #include "components/generic/PhysicsComponent.hpp"
 #include "components/damage/TakeJumpOnTopDamage.hpp"
 #include "components/damage/GiveNpcTouchDamageComponent.hpp"
+#include "components/damage/GiveProjectileDamageComponent.hpp"
 
 #include "spritesheet-frames/NPCSpritesheetFrames.hpp"
 
@@ -186,6 +187,7 @@ namespace prefabs
 
         if (registry.has<TakeJumpOnTopDamageComponent>(id)) registry.remove<TakeJumpOnTopDamageComponent>(id);
         if (registry.has<GiveNpcTouchDamageComponent>(id)) registry.remove<GiveNpcTouchDamageComponent>(id);
+        if (!registry.has<GiveProjectileDamageComponent>(id)) registry.emplace<GiveProjectileDamageComponent>(id, 1);
     }
 
     void ShopkeeperDeadState::exit(ShopkeeperScript&, entt::entity id)


### PR DESCRIPTION
Fixes the problem of projectiles giving inaccurate amount of damage due to constant collision between the projectile and body.

Additionally, making dead bodies projectiles (affects Shopkeeper/Damsel/Caveman).