### PR TITLE
Fixed the pick-up bug on platforms with input based on SDL2

### DIFF
--- a/src/input/src/Input_Android.cpp
+++ b/src/input/src/Input_Android.cpp
@@ -113,7 +113,7 @@ void Input::poll()
                 _toggles.out_rope.feed(v);
             }
         }
-
-        fill_input_events();
     }
+
+    fill_input_events();
 }

--- a/src/input/src/Input_Darwin.cpp
+++ b/src/input/src/Input_Darwin.cpp
@@ -115,7 +115,7 @@ void Input::poll()
                 _toggles.out_rope.feed(v);
             }
         }
-
-        fill_input_events();
     }
+
+    fill_input_events();
 }


### PR DESCRIPTION
As in title. Caused picked-up items to be dropped instantly.