### PR TITLE
Added cheat console (desktop only)

### DIFF
--- a/cmake/DependenciesDarwin.cmake
+++ b/cmake/DependenciesDarwin.cmake
@@ -21,7 +21,9 @@ macro(add_darwin_dependencies)
     target_compile_definitions(Dependencies INTERFACE
             SPELUNKY_PSP_PLATFORM_DARWIN
             SPELUNKY_PSP_PLATFORM_DESKTOP
+            SPELUNKY_PSP_WITH_IMGUI
     )
+    set(SPELUNKY_PSP_WITH_IMGUI TRUE)
 endmacro()
 
 macro(spelunky_psp_post_build_darwin)

--- a/cmake/DependenciesLinux.cmake
+++ b/cmake/DependenciesLinux.cmake
@@ -18,10 +18,13 @@ macro(add_linux_dependencies)
 
     add_library(Dependencies INTERFACE)
     target_link_libraries(Dependencies INTERFACE SDL_2_XX)
+    # TODO: Separate target, i.e PlatformDefinitions
     target_compile_definitions(Dependencies INTERFACE
         SPELUNKY_PSP_PLATFORM_LINUX
         SPELUNKY_PSP_PLATFORM_DESKTOP
+        SPELUNKY_PSP_WITH_IMGUI
     )
+    set(SPELUNKY_PSP_WITH_IMGUI TRUE)
 endmacro()
 
 macro(spelunky_psp_post_build_linux)

--- a/cmake/DependenciesWindows.cmake
+++ b/cmake/DependenciesWindows.cmake
@@ -14,7 +14,9 @@ macro(add_windows_dependencies)
     target_compile_definitions(Dependencies INTERFACE
             SPELUNKY_PSP_PLATFORM_WINDOWS
             SPELUNKY_PSP_PLATFORM_DESKTOP
-            )
+            SPELUNKY_PSP_WITH_IMGUI
+    )
+    set(SPELUNKY_PSP_WITH_IMGUI TRUE)
 endmacro()
 
 macro(spelunky_psp_post_build_windows)

--- a/src/game-loop/CMakeLists.txt
+++ b/src/game-loop/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(GameLoop STATIC
         src/game-loop/GameLoopStartedState.cpp
         src/game-loop/GameLoopLevelSummaryState.cpp
         src/game-loop/GameLoopScoresState.cpp
+        src/game-loop/GameLoopSandboxState.cpp
 
         interface/game-loop/GameLoop.hpp
         interface/game-loop/GameLoopBaseState.hpp
@@ -17,6 +18,7 @@ add_library(GameLoop STATIC
         interface/game-loop/GameLoopStartedState.hpp
         interface/game-loop/GameLoopLevelSummaryState.hpp
         interface/game-loop/GameLoopScoresState.hpp
+        interface/game-loop/GameLoopSandboxState.hpp
 
         # Main dude:
 

--- a/src/game-loop/CMakeLists.txt
+++ b/src/game-loop/CMakeLists.txt
@@ -371,5 +371,6 @@ target_link_libraries(GameLoop
         Audio
         glad
         GraphicsUtils
-        imgui
+        $<$<BOOL:${SPELUNKY_PSP_WITH_IMGUI}>:imgui>
+        Dependencies
 )

--- a/src/game-loop/CMakeLists.txt
+++ b/src/game-loop/CMakeLists.txt
@@ -334,6 +334,10 @@ add_library(GameLoop STATIC
 
         src/other/ParticleGenerator.cpp
         src/other/Inventory.cpp
+        src/prefabs/ui/CheatConsole.cpp
+        src/populator/ItemFactory.cpp
+        src/populator/LootFactory.cpp
+        src/populator/NpcFactory.cpp
         interface/other/PhysicsComponentType.hpp
         interface/other/Inventory.hpp
         interface/other/InventoryEvent.hpp
@@ -343,8 +347,10 @@ add_library(GameLoop STATIC
         include/other/ParticleGenerator.hpp
         include/components/generic/ImguiComponent.hpp
         include/prefabs/ui/CheatConsole.hpp
-        src/prefabs/ui/CheatConsole.cpp
-)
+        include/populator/ItemFactory.hpp
+        include/populator/NpcFactory.hpp
+        include/populator/LootFactory.hpp
+        src/other/NpcType.cpp src/other/ItemType.cpp include/other/CheatConsoleInterpreter.h src/other/CheatConsoleInterpreter.cpp interface/game-loop/GameLoopState.hpp src/game-loop/GameLoopState.cpp)
 
 target_include_directories(GameLoop
         PRIVATE include interface

--- a/src/game-loop/CMakeLists.txt
+++ b/src/game-loop/CMakeLists.txt
@@ -326,6 +326,10 @@ add_library(GameLoop STATIC
 
         # Other:
 
+        src/other/CheatConsoleInterpreter.cpp
+        src/other/NpcType.cpp
+        src/other/ItemType.cpp
+        src/game-loop/GameLoopState.cpp
         src/populator/Populator.cpp
         src/populator/Shop.cpp
         include/populator/Populator.hpp
@@ -339,6 +343,7 @@ add_library(GameLoop STATIC
         src/populator/LootFactory.cpp
         src/populator/NpcFactory.cpp
         interface/other/PhysicsComponentType.hpp
+        interface/game-loop/GameLoopState.hpp
         interface/other/Inventory.hpp
         interface/other/InventoryEvent.hpp
         interface/other/ItemType.hpp
@@ -350,7 +355,8 @@ add_library(GameLoop STATIC
         include/populator/ItemFactory.hpp
         include/populator/NpcFactory.hpp
         include/populator/LootFactory.hpp
-        src/other/NpcType.cpp src/other/ItemType.cpp include/other/CheatConsoleInterpreter.h src/other/CheatConsoleInterpreter.cpp interface/game-loop/GameLoopState.hpp src/game-loop/GameLoopState.cpp)
+        include/other/CheatConsoleInterpreter.h
+)
 
 target_include_directories(GameLoop
         PRIVATE include interface

--- a/src/game-loop/CMakeLists.txt
+++ b/src/game-loop/CMakeLists.txt
@@ -339,6 +339,9 @@ add_library(GameLoop STATIC
         include/other/LootCollectedEvent.hpp
         include/other/NpcType.hpp
         include/other/ParticleGenerator.hpp
+        include/components/generic/ImguiComponent.hpp
+        include/prefabs/ui/CheatConsole.hpp
+        src/prefabs/ui/CheatConsole.cpp
 )
 
 target_include_directories(GameLoop
@@ -366,4 +369,5 @@ target_link_libraries(GameLoop
         Audio
         glad
         GraphicsUtils
+        imgui
 )

--- a/src/game-loop/include/components/generic/ImguiComponent.hpp
+++ b/src/game-loop/include/components/generic/ImguiComponent.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <functional>
+
+struct ImguiComponent
+{
+    std::function<void()> render_callback;
+};

--- a/src/game-loop/include/other/CheatConsoleInterpreter.h
+++ b/src/game-loop/include/other/CheatConsoleInterpreter.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <vector>
+#include <string>
+#include <functional>
+#include <map>
+
+#include "other/ItemType.hpp"
+#include "other/NpcType.hpp"
+#include "game-loop/GameLoopState.hpp"
+#include "LootType.hpp"
+
+class CheatConsoleInterpreter
+{
+public:
+    using Command = std::vector<std::string>;
+    using CommandHandlerResult = std::pair<bool, std::string>;
+    using CommandHandler = std::function<CommandHandlerResult(const Command&)>;
+    CheatConsoleInterpreter();
+
+    const CommandHandler& get_spawn_command_handler() const;
+    const CommandHandler& get_enter_command_handler() const;
+private:
+    std::map<std::string, ItemType> _string_to_item_type_map;
+    std::map<std::string, NpcType> _string_to_npc_type_map;
+    std::map<std::string, LootType> _string_to_loot_type_map;
+    std::map<std::string, GameLoopState> _string_to_game_loop_state_map;
+
+    CommandHandler _spawn_command_handler;
+    CommandHandler _enter_command_handler;
+};

--- a/src/game-loop/include/other/NpcType.hpp
+++ b/src/game-loop/include/other/NpcType.hpp
@@ -1,8 +1,13 @@
 #pragma once
 
-enum class NpcType
+#include <cassert>
+#include <cstdint>
+
+using NpcType_t = std::uint16_t;
+
+enum class NpcType : NpcType_t
 {
-    NONE,
+    NONE = 0,
     SNAKE,
     BAT,
     CAVEMAN,
@@ -11,5 +16,8 @@ enum class NpcType
     SHOPKEEPER,
     DAMSEL,
     BLUE_FROG,
-    RED_FROG
+    RED_FROG,
+    _SIZE
 };
+
+const char* to_string(NpcType npc_type);

--- a/src/game-loop/include/populator/ItemFactory.hpp
+++ b/src/game-loop/include/populator/ItemFactory.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "other/ItemType.hpp"
+#include <entt/entt.hpp>
+
+class ItemFactory {
+public:
+    static entt::entity make(ItemType);
+    static entt::entity make(ItemType, float pos_x, float pos_y);
+};

--- a/src/game-loop/include/populator/LootFactory.hpp
+++ b/src/game-loop/include/populator/LootFactory.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <entt/entt.hpp>
+#include "LootType.hpp"
+
+class LootFactory {
+public:
+    static entt::entity make(LootType);
+    static entt::entity make(LootType, float pos_x, float pos_y);
+};

--- a/src/game-loop/include/populator/NpcFactory.hpp
+++ b/src/game-loop/include/populator/NpcFactory.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "other/NpcType.hpp"
+#include <entt/entt.hpp>
+
+class NpcFactory {
+public:
+    static entt::entity make(NpcType);
+    static entt::entity make(NpcType, float pos_x, float pos_y);
+};

--- a/src/game-loop/include/prefabs/ui/CheatConsole.hpp
+++ b/src/game-loop/include/prefabs/ui/CheatConsole.hpp
@@ -4,17 +4,20 @@
 #include "viewport/Viewport.hpp"
 #include "game-loop/GameLoop.hpp"
 
+#include <vector>
+#include <functional>
+
 namespace prefabs
 {
     class CheatConsoleComponent
     {
     public:
         bool is_state_change_requested() const { return _state_change_requested; }
-        void request_state_change(GameLoop::State requested_state) { _requested_state = requested_state; _state_change_requested = true; }
-        GameLoop::State get_requested_state() const { return _requested_state;}
+        void request_state_change(GameLoopState requested_state) { _requested_state = requested_state; _state_change_requested = true; }
+        GameLoopState get_requested_state() const { return _requested_state;}
     private:
         bool _state_change_requested = false;
-        GameLoop::State _requested_state{GameLoop::State::CURRENT};
+        GameLoopState _requested_state{GameLoopState::CURRENT};
     };
 
     struct CheatConsole

--- a/src/game-loop/include/prefabs/ui/CheatConsole.hpp
+++ b/src/game-loop/include/prefabs/ui/CheatConsole.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "entt/entt.hpp"
+#include "viewport/Viewport.hpp"
+
+namespace prefabs
+{
+    struct CheatConsole
+    {
+        static entt::entity create(const std::shared_ptr<Viewport>& viewport);
+    };
+}

--- a/src/game-loop/include/prefabs/ui/CheatConsole.hpp
+++ b/src/game-loop/include/prefabs/ui/CheatConsole.hpp
@@ -2,9 +2,15 @@
 
 #include "entt/entt.hpp"
 #include "viewport/Viewport.hpp"
+#include "game-loop/GameLoop.hpp"
 
 namespace prefabs
 {
+    struct CheatConsoleComponent
+    {
+        GameLoop::State state{GameLoop::State::CURRENT};
+    };
+
     struct CheatConsole
     {
         static entt::entity create(const std::shared_ptr<Viewport>& viewport);

--- a/src/game-loop/include/prefabs/ui/CheatConsole.hpp
+++ b/src/game-loop/include/prefabs/ui/CheatConsole.hpp
@@ -6,9 +6,15 @@
 
 namespace prefabs
 {
-    struct CheatConsoleComponent
+    class CheatConsoleComponent
     {
-        GameLoop::State state{GameLoop::State::CURRENT};
+    public:
+        bool is_state_change_requested() const { return _state_change_requested; }
+        void request_state_change(GameLoop::State requested_state) { _requested_state = requested_state; _state_change_requested = true; }
+        GameLoop::State get_requested_state() const { return _requested_state;}
+    private:
+        bool _state_change_requested = false;
+        GameLoop::State _requested_state{GameLoop::State::CURRENT};
     };
 
     struct CheatConsole

--- a/src/game-loop/include/system/RenderingSystem.hpp
+++ b/src/game-loop/include/system/RenderingSystem.hpp
@@ -21,6 +21,8 @@ public:
 
 private:
 
+    void update_opengl(std::uint32_t delta_time_ms);
+    void update_imgui();
     void use_camera(CameraType camera_type);
     void use_model_view_camera();
     void use_screen_space_camera();

--- a/src/game-loop/interface/game-loop/GameLoop.hpp
+++ b/src/game-loop/interface/game-loop/GameLoop.hpp
@@ -48,6 +48,8 @@ public:
 
     GameLoop(const std::shared_ptr<Viewport>&);
     std::function<bool(uint32_t delta_time_ms)>& get();
+    GameLoopBaseState* get_game_loop_state_ptr(State);
+
 private:
 
     friend class GameLoopBaseState;

--- a/src/game-loop/interface/game-loop/GameLoop.hpp
+++ b/src/game-loop/interface/game-loop/GameLoop.hpp
@@ -34,6 +34,16 @@ class ShoppingSystem;
 class GameLoop
 {
 public:
+    enum class State
+    {
+        MAIN_MENU = 0,
+        PLAYING,
+        STARTED,
+        LEVEL_SUMMARY,
+        SCORES,
+        CURRENT
+    };
+
     GameLoop(const std::shared_ptr<Viewport>&);
     std::function<bool(uint32_t delta_time_ms)>& get();
 private:

--- a/src/game-loop/interface/game-loop/GameLoop.hpp
+++ b/src/game-loop/interface/game-loop/GameLoop.hpp
@@ -13,6 +13,7 @@
 #include "game-loop/GameLoopPlayingState.hpp"
 #include "game-loop/GameLoopStartedState.hpp"
 #include "game-loop/GameLoopScoresState.hpp"
+#include "game-loop/GameLoopSandboxState.hpp"
 
 #include <entt/entt.hpp>
 
@@ -41,6 +42,7 @@ public:
         STARTED,
         LEVEL_SUMMARY,
         SCORES,
+        SANDBOX,
         CURRENT
     };
 
@@ -54,6 +56,7 @@ private:
     friend class GameLoopStartedState;
     friend class GameLoopLevelSummaryState;
     friend class GameLoopScoresState;
+    friend class GameLoopSandboxState;
 
     struct
     {
@@ -62,6 +65,7 @@ private:
         GameLoopStartedState started;
         GameLoopLevelSummaryState level_summary;
         GameLoopScoresState scores;
+        GameLoopSandboxState sandbox;
         GameLoopBaseState* current;
     } _states;
 

--- a/src/game-loop/interface/game-loop/GameLoop.hpp
+++ b/src/game-loop/interface/game-loop/GameLoop.hpp
@@ -14,6 +14,7 @@
 #include "game-loop/GameLoopStartedState.hpp"
 #include "game-loop/GameLoopScoresState.hpp"
 #include "game-loop/GameLoopSandboxState.hpp"
+#include "game-loop/GameLoopState.hpp"
 
 #include <entt/entt.hpp>
 
@@ -35,20 +36,9 @@ class ShoppingSystem;
 class GameLoop
 {
 public:
-    enum class State
-    {
-        MAIN_MENU = 0,
-        PLAYING,
-        STARTED,
-        LEVEL_SUMMARY,
-        SCORES,
-        SANDBOX,
-        CURRENT
-    };
-
     GameLoop(const std::shared_ptr<Viewport>&);
     std::function<bool(uint32_t delta_time_ms)>& get();
-    GameLoopBaseState* get_game_loop_state_ptr(State);
+    GameLoopBaseState* get_game_loop_state_ptr(GameLoopState);
 
 private:
 

--- a/src/game-loop/interface/game-loop/GameLoopBaseState.hpp
+++ b/src/game-loop/interface/game-loop/GameLoopBaseState.hpp
@@ -4,6 +4,7 @@
 
 class GameLoop;
 
+// TODO: Rename to IGameLoopState to not confuse with GameLoopState enum
 class GameLoopBaseState
 {
 public:

--- a/src/game-loop/interface/game-loop/GameLoopMainMenuState.hpp
+++ b/src/game-loop/interface/game-loop/GameLoopMainMenuState.hpp
@@ -14,6 +14,7 @@ public:
     void enter(GameLoop&) override;
     void exit(GameLoop&) override;
 private:
+    entt::entity _cheat_console = entt::null;
     entt::entity _main_dude = entt::null;
     entt::entity _pause_overlay = entt::null;
     entt::entity _death_overlay = entt::null;

--- a/src/game-loop/interface/game-loop/GameLoopPlayingState.hpp
+++ b/src/game-loop/interface/game-loop/GameLoopPlayingState.hpp
@@ -32,4 +32,5 @@ private:
     entt::entity _hud = entt::null;
     entt::entity _pause_overlay = entt::null;
     entt::entity _death_overlay = entt::null;
+    entt::entity _cheat_console = entt::null;
 };

--- a/src/game-loop/interface/game-loop/GameLoopSandboxState.hpp
+++ b/src/game-loop/interface/game-loop/GameLoopSandboxState.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <memory>
+#include <entt/entt.hpp>
+#include "game-loop/GameLoopBaseState.hpp"
+
+class GameLoop;
+class PauseOverlayComponent;
+class ScoresOverlayComponent;
+
+class GameLoopSandboxState : public GameLoopBaseState
+{
+public:
+    GameLoopBaseState* update(GameLoop&, uint32_t delta_time_ms) override;
+    void enter(GameLoop&) override;
+    void exit(GameLoop&) override;
+private:
+    entt::entity _main_dude = entt::null;
+    entt::entity _pause_overlay = entt::null;
+    entt::entity _death_overlay = entt::null;
+    entt::entity _cheat_console = entt::null;
+};

--- a/src/game-loop/interface/game-loop/GameLoopScoresState.hpp
+++ b/src/game-loop/interface/game-loop/GameLoopScoresState.hpp
@@ -18,4 +18,5 @@ private:
     entt::entity _main_dude = entt::null;
     entt::entity _pause_overlay = entt::null;
     entt::entity _death_overlay = entt::null;
+    entt::entity _cheat_console = entt::null;
 };

--- a/src/game-loop/interface/game-loop/GameLoopState.hpp
+++ b/src/game-loop/interface/game-loop/GameLoopState.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <cstdint>
+
+using GameLoopState_t = std::uint16_t;
+enum class GameLoopState : GameLoopState_t
+{
+    MAIN_MENU = 0,
+    PLAYING,
+    STARTED,
+    LEVEL_SUMMARY,
+    SCORES,
+    SANDBOX,
+    CURRENT,
+    _SIZE
+};
+
+const char* to_string(GameLoopState);

--- a/src/game-loop/interface/other/ItemType.hpp
+++ b/src/game-loop/interface/other/ItemType.hpp
@@ -1,8 +1,12 @@
 #pragma once
 
-enum class ItemType
+#include <cassert>
+#include <cstdint>
+
+using ItemType_t = std::uint16_t;
+enum class ItemType : ItemType_t
 {
-    ARROW,
+    ARROW = 0,
     BOMB,
     CAPE,
     CHEST,
@@ -30,3 +34,5 @@ enum class ItemType
     FLARE,
     _SIZE
 };
+
+const char* to_string(ItemType item_type);

--- a/src/game-loop/src/game-loop/GameLoop.cpp
+++ b/src/game-loop/src/game-loop/GameLoop.cpp
@@ -58,21 +58,21 @@ GameLoop::GameLoop(const std::shared_ptr<Viewport>& viewport)
     };
 }
 
-GameLoopBaseState *GameLoop::get_game_loop_state_ptr(GameLoop::State state) {
+GameLoopBaseState *GameLoop::get_game_loop_state_ptr(GameLoopState state) {
     switch (state) {
-        case State::MAIN_MENU:
+        case GameLoopState::MAIN_MENU:
             return &_states.main_menu;
-        case State::PLAYING:
+        case GameLoopState::PLAYING:
             return &_states.playing;
-        case State::STARTED:
+        case GameLoopState::STARTED:
             return &_states.started;
-        case State::LEVEL_SUMMARY:
+        case GameLoopState::LEVEL_SUMMARY:
             return &_states.level_summary;
-        case State::SCORES:
+        case GameLoopState::SCORES:
             return &_states.scores;
-        case State::SANDBOX:
+        case GameLoopState::SANDBOX:
             return &_states.sandbox;
-        case State::CURRENT:
+        case GameLoopState::CURRENT:
             return _states.current;
         default: assert(false);
     }

--- a/src/game-loop/src/game-loop/GameLoop.cpp
+++ b/src/game-loop/src/game-loop/GameLoop.cpp
@@ -57,3 +57,23 @@ GameLoop::GameLoop(const std::shared_ptr<Viewport>& viewport)
         return _exit;
     };
 }
+
+GameLoopBaseState *GameLoop::get_game_loop_state_ptr(GameLoop::State state) {
+    switch (state) {
+        case State::MAIN_MENU:
+            return &_states.main_menu;
+        case State::PLAYING:
+            return &_states.playing;
+        case State::STARTED:
+            return &_states.started;
+        case State::LEVEL_SUMMARY:
+            return &_states.level_summary;
+        case State::SCORES:
+            return &_states.scores;
+        case State::SANDBOX:
+            return &_states.sandbox;
+        case State::CURRENT:
+            return _states.current;
+        default: assert(false);
+    }
+}

--- a/src/game-loop/src/game-loop/GameLoopMainMenuState.cpp
+++ b/src/game-loop/src/game-loop/GameLoopMainMenuState.cpp
@@ -105,6 +105,28 @@ GameLoopBaseState *GameLoopMainMenuState::update(GameLoop& game_loop, uint32_t d
         }
     }
 
+
+    auto& cheat_console = registry.get<prefabs::CheatConsoleComponent>(_cheat_console);
+    switch (cheat_console.state)
+    {
+        case GameLoop::State::SCORES:
+        {
+            cheat_console.state = GameLoop::State::CURRENT;
+            return &game_loop._states.scores;
+        }
+        case GameLoop::State::MAIN_MENU:
+        {
+            cheat_console.state = GameLoop::State::CURRENT;
+            return &game_loop._states.main_menu;
+        }
+        case GameLoop::State::PLAYING:
+        {
+            cheat_console.state = GameLoop::State::CURRENT;
+            return &game_loop._states.playing;
+        }
+        default: {}
+    }
+
     if (position.y_center <= EXIT_LEVEL_Y)
     {
         log_info("Quitting using rope.");
@@ -156,7 +178,7 @@ void GameLoopMainMenuState::enter(GameLoop& game_loop)
 
     _pause_overlay = prefabs::PauseOverlay::create(game_loop._viewport, PauseOverlayComponent::Type::MAIN_MENU);
     _main_dude = prefabs::MainDude::create(17.5, 9.5);
-    prefabs::CheatConsole::create(game_loop._viewport);
+    _cheat_console = prefabs::CheatConsole::create(game_loop._viewport);
 
     game_loop._level_summary_tracker->reset();
 

--- a/src/game-loop/src/game-loop/GameLoopMainMenuState.cpp
+++ b/src/game-loop/src/game-loop/GameLoopMainMenuState.cpp
@@ -124,6 +124,11 @@ GameLoopBaseState *GameLoopMainMenuState::update(GameLoop& game_loop, uint32_t d
             cheat_console.state = GameLoop::State::CURRENT;
             return &game_loop._states.playing;
         }
+        case GameLoop::State::SANDBOX:
+        {
+            cheat_console.state = GameLoop::State::CURRENT;
+            return &game_loop._states.sandbox;
+        }
         default: {}
     }
 
@@ -157,6 +162,7 @@ void GameLoopMainMenuState::enter(GameLoop& game_loop)
     auto& model_view_camera = rendering_system->get_model_view_camera();
     model_view_camera.set_x_not_rounded(game_loop._viewport->get_width_world_units() / 4.0f);
     model_view_camera.set_y_not_rounded(game_loop._viewport->get_height_world_units() / 4.0f);
+    model_view_camera.update_gl_modelview_matrix();
 
     prefabs::StartSign::create(5.55, 9.0);
     prefabs::ScoresSign::create(9.55, 9.0);

--- a/src/game-loop/src/game-loop/GameLoopMainMenuState.cpp
+++ b/src/game-loop/src/game-loop/GameLoopMainMenuState.cpp
@@ -34,6 +34,7 @@
 #include "prefabs/items/Flare.hpp"
 #include "prefabs/main-dude/MainDude.hpp"
 #include "prefabs/ui/PauseOverlay.hpp"
+#include "prefabs/ui/CheatConsole.hpp"
 
 #include <cmath>
 
@@ -155,6 +156,7 @@ void GameLoopMainMenuState::enter(GameLoop& game_loop)
 
     _pause_overlay = prefabs::PauseOverlay::create(game_loop._viewport, PauseOverlayComponent::Type::MAIN_MENU);
     _main_dude = prefabs::MainDude::create(17.5, 9.5);
+    prefabs::CheatConsole::create(game_loop._viewport);
 
     game_loop._level_summary_tracker->reset();
 

--- a/src/game-loop/src/game-loop/GameLoopMainMenuState.cpp
+++ b/src/game-loop/src/game-loop/GameLoopMainMenuState.cpp
@@ -105,37 +105,15 @@ GameLoopBaseState *GameLoopMainMenuState::update(GameLoop& game_loop, uint32_t d
         }
     }
 
-
-    auto& cheat_console = registry.get<prefabs::CheatConsoleComponent>(_cheat_console);
-    switch (cheat_console.state)
-    {
-        case GameLoop::State::SCORES:
-        {
-            cheat_console.state = GameLoop::State::CURRENT;
-            return &game_loop._states.scores;
-        }
-        case GameLoop::State::MAIN_MENU:
-        {
-            cheat_console.state = GameLoop::State::CURRENT;
-            return &game_loop._states.main_menu;
-        }
-        case GameLoop::State::PLAYING:
-        {
-            cheat_console.state = GameLoop::State::CURRENT;
-            return &game_loop._states.playing;
-        }
-        case GameLoop::State::SANDBOX:
-        {
-            cheat_console.state = GameLoop::State::CURRENT;
-            return &game_loop._states.sandbox;
-        }
-        default: {}
-    }
-
     if (position.y_center <= EXIT_LEVEL_Y)
     {
         log_info("Quitting using rope.");
         game_loop._exit = true;
+    }
+
+    auto& cheat_console = registry.get<prefabs::CheatConsoleComponent>(_cheat_console);
+    if (cheat_console.is_state_change_requested()) {
+        return game_loop.get_game_loop_state_ptr(cheat_console.get_requested_state());
     }
 
     return this;

--- a/src/game-loop/src/game-loop/GameLoopPlayingState.cpp
+++ b/src/game-loop/src/game-loop/GameLoopPlayingState.cpp
@@ -36,6 +36,7 @@
 #include "Level.hpp"
 #include "audio/Audio.hpp"
 #include "populator/Populator.hpp"
+#include "prefabs/ui/CheatConsole.hpp"
 
 GameLoopBaseState *GameLoopPlayingState::update(GameLoop& game_loop, uint32_t delta_time_ms)
 {
@@ -112,6 +113,27 @@ GameLoopBaseState *GameLoopPlayingState::update(GameLoop& game_loop, uint32_t de
 
     game_loop._level_summary_tracker->update(delta_time_ms);
 
+    auto& cheat_console = registry.get<prefabs::CheatConsoleComponent>(_cheat_console);
+    switch (cheat_console.state)
+    {
+        case GameLoop::State::SCORES:
+        {
+            cheat_console.state = GameLoop::State::CURRENT;
+            return &game_loop._states.scores;
+        }
+        case GameLoop::State::MAIN_MENU:
+        {
+            cheat_console.state = GameLoop::State::CURRENT;
+            return &game_loop._states.main_menu;
+        }
+        case GameLoop::State::PLAYING:
+        {
+            cheat_console.state = GameLoop::State::CURRENT;
+            return &game_loop._states.playing;
+        }
+        default: {}
+    }
+
     return this;
 }
 
@@ -147,6 +169,7 @@ void GameLoopPlayingState::enter(GameLoop& game_loop)
     _pause_overlay = prefabs::PauseOverlay::create(game_loop._viewport, PauseOverlayComponent::Type::PLAYING);
     _death_overlay = prefabs::DeathOverlay::create(game_loop._viewport);
     _hud = prefabs::HudOverlay::create(game_loop._viewport);
+    _cheat_console = prefabs::CheatConsole::create(game_loop._viewport);
 
     game_loop._rendering_system->sort();
 

--- a/src/game-loop/src/game-loop/GameLoopPlayingState.cpp
+++ b/src/game-loop/src/game-loop/GameLoopPlayingState.cpp
@@ -114,24 +114,8 @@ GameLoopBaseState *GameLoopPlayingState::update(GameLoop& game_loop, uint32_t de
     game_loop._level_summary_tracker->update(delta_time_ms);
 
     auto& cheat_console = registry.get<prefabs::CheatConsoleComponent>(_cheat_console);
-    switch (cheat_console.state)
-    {
-        case GameLoop::State::SCORES:
-        {
-            cheat_console.state = GameLoop::State::CURRENT;
-            return &game_loop._states.scores;
-        }
-        case GameLoop::State::MAIN_MENU:
-        {
-            cheat_console.state = GameLoop::State::CURRENT;
-            return &game_loop._states.main_menu;
-        }
-        case GameLoop::State::PLAYING:
-        {
-            cheat_console.state = GameLoop::State::CURRENT;
-            return &game_loop._states.playing;
-        }
-        default: {}
+    if (cheat_console.is_state_change_requested()) {
+        return game_loop.get_game_loop_state_ptr(cheat_console.get_requested_state());
     }
 
     return this;

--- a/src/game-loop/src/game-loop/GameLoopSandboxState.cpp
+++ b/src/game-loop/src/game-loop/GameLoopSandboxState.cpp
@@ -1,0 +1,141 @@
+#include "game-loop/GameLoopSandboxState.hpp"
+#include "game-loop/GameLoop.hpp"
+
+#include "EntityRegistry.hpp"
+
+#include "prefabs/main-dude/MainDude.hpp"
+#include "prefabs/ui/ScoresOverlay.hpp"
+#include "prefabs/ui/PauseOverlay.hpp"
+#include "prefabs/props/ResetSign.hpp"
+
+#include "components/specialized/PauseOverlayComponent.hpp"
+#include "components/specialized/MainDudeComponent.hpp"
+
+#include "system/RenderingSystem.hpp"
+#include "system/ScriptingSystem.hpp"
+#include "system/PhysicsSystem.hpp"
+#include "system/ShoppingSystem.hpp"
+#include "system/AnimationSystem.hpp"
+#include "system/InputSystem.hpp"
+#include "system/DisposingSystem.hpp"
+#include "system/ParticleSystem.hpp"
+#include "system/ItemSystem.hpp"
+
+#include "populator/Populator.hpp"
+#include "logger/log.h"
+#include "ModelViewCamera.hpp"
+#include "ScreenSpaceCamera.hpp"
+#include "CameraType.hpp"
+#include "Level.hpp"
+#include "other/Inventory.hpp"
+#include "prefabs/ui/CheatConsole.hpp"
+
+GameLoopBaseState *GameLoopSandboxState::update(GameLoop& game_loop, uint32_t delta_time_ms)
+{
+    auto& registry = EntityRegistry::instance().get_registry();
+
+    auto& rendering_system = game_loop._rendering_system;
+    auto& scripting_system = game_loop._scripting_system;
+    auto& physics_system = game_loop._physics_system;
+    auto& animation_system = game_loop._animation_system;
+    auto& input_system = game_loop._input_system;
+    auto& disposing_system = game_loop._disposing_system;
+    auto& particle_system = game_loop._particle_system;
+    auto& item_system = game_loop._item_system;
+
+    // Adjust camera to follow main dude:
+    auto& position = registry.get<PositionComponent>(_main_dude);
+    auto& model_view_camera = game_loop._rendering_system->get_model_view_camera();
+
+    model_view_camera.adjust_to_bounding_box(position.x_center, position.y_center);
+    model_view_camera.adjust_to_level_boundaries(Consts ::LEVEL_WIDTH_TILES, Consts::LEVEL_HEIGHT_TILES);
+    model_view_camera.update_gl_modelview_matrix();
+
+    rendering_system->update(delta_time_ms);
+    input_system->update(delta_time_ms);
+
+    auto& pause = registry.get<PauseOverlayComponent>(_pause_overlay);
+
+    if (pause.is_paused())
+    {
+        if (pause.is_quit_requested())
+        {
+            log_info("Quit requested.");
+            game_loop._exit = true;
+        }
+
+        pause.update(registry);
+    }
+    else
+    {
+        physics_system->update(delta_time_ms);
+        animation_system->update(delta_time_ms);
+        scripting_system->update(delta_time_ms);
+        disposing_system->update(delta_time_ms);
+        particle_system->update(delta_time_ms);
+        item_system->update(delta_time_ms);
+    }
+
+    auto& dude = registry.get<MainDudeComponent>(_main_dude);
+
+    if (dude.entered_door())
+    {
+        return &game_loop._states.main_menu;
+    }
+
+
+    auto& cheat_console = registry.get<prefabs::CheatConsoleComponent>(_cheat_console);
+    switch (cheat_console.state)
+    {
+        case GameLoop::State::SCORES:
+        {
+            cheat_console.state = GameLoop::State::CURRENT;
+            return &game_loop._states.scores;
+        }
+        case GameLoop::State::MAIN_MENU:
+        {
+            cheat_console.state = GameLoop::State::CURRENT;
+            return &game_loop._states.main_menu;
+        }
+        case GameLoop::State::PLAYING:
+        {
+            cheat_console.state = GameLoop::State::CURRENT;
+            return &game_loop._states.playing;
+        }
+        default: {}
+    }
+
+    return this;
+}
+
+void GameLoopSandboxState::enter(GameLoop& game_loop)
+{
+    log_info("Entered GameLoopSandboxState");
+
+    auto& registry = EntityRegistry::instance().get_registry();
+
+    auto& rendering_system = game_loop._rendering_system;
+
+    Level::instance().get_tile_batch().clean();
+    Level::instance().get_tile_batch().generate_frame();
+    Level::instance().get_tile_batch().generate_cave_background();
+    Level::instance().get_tile_batch().batch_vertices();
+    Level::instance().get_tile_batch().add_render_entity(registry);
+
+    auto& inventory = Inventory::instance();
+    inventory.clear_items();
+    game_loop._shopping_system = std::make_shared<ShoppingSystem>();
+
+    float pos_x = Consts::LEVEL_WIDTH_TILES / 2;
+    float pos_y = Consts::LEVEL_HEIGHT_TILES / 2;
+
+    _main_dude = prefabs::MainDude::create(pos_x, pos_y);
+    _pause_overlay = prefabs::PauseOverlay::create(game_loop._viewport, PauseOverlayComponent::Type::SCORES);
+    _cheat_console = prefabs::CheatConsole::create(game_loop._viewport);
+}
+
+void GameLoopSandboxState::exit(GameLoop& game_loop)
+{
+    auto& registry = EntityRegistry::instance().get_registry();
+    registry.clear();
+}

--- a/src/game-loop/src/game-loop/GameLoopSandboxState.cpp
+++ b/src/game-loop/src/game-loop/GameLoopSandboxState.cpp
@@ -83,26 +83,9 @@ GameLoopBaseState *GameLoopSandboxState::update(GameLoop& game_loop, uint32_t de
         return &game_loop._states.main_menu;
     }
 
-
     auto& cheat_console = registry.get<prefabs::CheatConsoleComponent>(_cheat_console);
-    switch (cheat_console.state)
-    {
-        case GameLoop::State::SCORES:
-        {
-            cheat_console.state = GameLoop::State::CURRENT;
-            return &game_loop._states.scores;
-        }
-        case GameLoop::State::MAIN_MENU:
-        {
-            cheat_console.state = GameLoop::State::CURRENT;
-            return &game_loop._states.main_menu;
-        }
-        case GameLoop::State::PLAYING:
-        {
-            cheat_console.state = GameLoop::State::CURRENT;
-            return &game_loop._states.playing;
-        }
-        default: {}
+    if (cheat_console.is_state_change_requested()) {
+        return game_loop.get_game_loop_state_ptr(cheat_console.get_requested_state());
     }
 
     return this;

--- a/src/game-loop/src/game-loop/GameLoopScoresState.cpp
+++ b/src/game-loop/src/game-loop/GameLoopScoresState.cpp
@@ -28,6 +28,7 @@
 #include "CameraType.hpp"
 #include "Level.hpp"
 #include "other/Inventory.hpp"
+#include "prefabs/ui/CheatConsole.hpp"
 
 GameLoopBaseState *GameLoopScoresState::update(GameLoop& game_loop, uint32_t delta_time_ms)
 {
@@ -74,6 +75,28 @@ GameLoopBaseState *GameLoopScoresState::update(GameLoop& game_loop, uint32_t del
         return &game_loop._states.main_menu;
     }
 
+
+    auto& cheat_console = registry.get<prefabs::CheatConsoleComponent>(_cheat_console);
+    switch (cheat_console.state)
+    {
+        case GameLoop::State::SCORES:
+        {
+            cheat_console.state = GameLoop::State::CURRENT;
+            return &game_loop._states.scores;
+        }
+        case GameLoop::State::MAIN_MENU:
+        {
+            cheat_console.state = GameLoop::State::CURRENT;
+            return &game_loop._states.main_menu;
+        }
+        case GameLoop::State::PLAYING:
+        {
+            cheat_console.state = GameLoop::State::CURRENT;
+            return &game_loop._states.playing;
+        }
+        default: {}
+    }
+
     return this;
 }
 
@@ -110,6 +133,7 @@ void GameLoopScoresState::enter(GameLoop& game_loop)
 
     _main_dude = prefabs::MainDude::create(pos_x, pos_y);
     _pause_overlay = prefabs::PauseOverlay::create(game_loop._viewport, PauseOverlayComponent::Type::SCORES);
+    _cheat_console = prefabs::CheatConsole::create(game_loop._viewport);
 
     prefabs::ScoresOverlay::create(game_loop._viewport);
     prefabs::ResetSign::create(16.5f, 10.5f);

--- a/src/game-loop/src/game-loop/GameLoopScoresState.cpp
+++ b/src/game-loop/src/game-loop/GameLoopScoresState.cpp
@@ -75,26 +75,9 @@ GameLoopBaseState *GameLoopScoresState::update(GameLoop& game_loop, uint32_t del
         return &game_loop._states.main_menu;
     }
 
-
     auto& cheat_console = registry.get<prefabs::CheatConsoleComponent>(_cheat_console);
-    switch (cheat_console.state)
-    {
-        case GameLoop::State::SCORES:
-        {
-            cheat_console.state = GameLoop::State::CURRENT;
-            return &game_loop._states.scores;
-        }
-        case GameLoop::State::MAIN_MENU:
-        {
-            cheat_console.state = GameLoop::State::CURRENT;
-            return &game_loop._states.main_menu;
-        }
-        case GameLoop::State::PLAYING:
-        {
-            cheat_console.state = GameLoop::State::CURRENT;
-            return &game_loop._states.playing;
-        }
-        default: {}
+    if (cheat_console.is_state_change_requested()) {
+        return game_loop.get_game_loop_state_ptr(cheat_console.get_requested_state());
     }
 
     return this;

--- a/src/game-loop/src/game-loop/GameLoopState.cpp
+++ b/src/game-loop/src/game-loop/GameLoopState.cpp
@@ -1,0 +1,18 @@
+#include "game-loop/GameLoopState.hpp"
+#include <cassert>
+
+const char *to_string(GameLoopState game_loop_state) {
+#define TO_STRING(x) case GameLoopState::x: return #x;
+    switch (game_loop_state) {
+        TO_STRING(MAIN_MENU);
+        TO_STRING(PLAYING);
+        TO_STRING(STARTED);
+        TO_STRING(LEVEL_SUMMARY);
+        TO_STRING(SCORES);
+        TO_STRING(SANDBOX);
+        TO_STRING(CURRENT);
+        TO_STRING(_SIZE);
+    }
+    assert(false);
+    return "Failed to match passed GameLoopState";
+}

--- a/src/game-loop/src/other/CheatConsoleInterpreter.cpp
+++ b/src/game-loop/src/other/CheatConsoleInterpreter.cpp
@@ -1,0 +1,115 @@
+#include "other/CheatConsoleInterpreter.h"
+#include "game-loop/GameLoop.hpp"
+#include "prefabs/ui/CheatConsole.hpp"
+#include "patterns/Singleton.hpp"
+#include "components/generic/PositionComponent.hpp"
+#include "populator/NpcFactory.hpp"
+#include "populator/ItemFactory.hpp"
+#include "populator/LootFactory.hpp"
+#include "EntityRegistry.hpp"
+#include "components/specialized/MainDudeComponent.hpp"
+
+template<class Enumerator, class Enumerator_t>
+std::map<std::string, Enumerator> populate_string_to_enum_map()
+{
+    std::map<std::string, Enumerator> out;
+    Enumerator_t enumerator_index = 0;
+    while (enumerator_index < static_cast<Enumerator_t>(Enumerator::_SIZE)) {
+        const auto enumerator = static_cast<Enumerator>(enumerator_index);
+        out.emplace(to_string(enumerator), enumerator);
+        enumerator_index++;
+    }
+    return out;
+}
+
+CheatConsoleInterpreter::CheatConsoleInterpreter()
+{
+    _string_to_item_type_map = populate_string_to_enum_map<ItemType, ItemType_t>();
+    _string_to_npc_type_map = populate_string_to_enum_map<NpcType, NpcType_t>();
+    _string_to_loot_type_map = populate_string_to_enum_map<LootType, LootType_t>();
+    _string_to_game_loop_state_map = populate_string_to_enum_map<GameLoopState, GameLoopState_t>();
+
+    _spawn_command_handler = CommandHandler([&](const Command& command){
+        if (command.size() != 2 && (command.at(0) == "HELP" || command.at(0) == "SPAWN")) {
+            return std::make_pair(false, "spawn <NpcType/ItemType>");
+        }
+
+        if (command.at(0) != "SPAWN") {
+            return std::make_pair(false, "");
+        }
+
+        const auto& type = command.at(1);
+        const auto npc_type_match = _string_to_npc_type_map.find(type);
+        const auto item_type_match = _string_to_item_type_map.find(type);
+        const auto loot_type_match = _string_to_loot_type_map.find(type);
+
+        auto& registry = EntityRegistry::instance().get_registry();
+        auto dudes = registry.view<MainDudeComponent>();
+        assert(dudes.size() == 1);
+        auto dude = dudes.front();
+        auto &dude_position = registry.get<PositionComponent>(dude);
+
+        const float offset_x = -2;
+        const float offset_y = -2;
+
+        if (npc_type_match != _string_to_npc_type_map.end())
+        {
+            const NpcType npc_type = npc_type_match->second;
+            NpcFactory::make(npc_type, dude_position.x_center + offset_x, dude_position.y_center + offset_y);
+            return std::make_pair(true, "spawning");
+        }
+
+        if (item_type_match != _string_to_item_type_map.end())
+        {
+            const ItemType item_type = item_type_match->second;
+            ItemFactory::make(item_type, dude_position.x_center + offset_x, dude_position.y_center + offset_y);
+            return std::make_pair(true, "spawning");
+        }
+
+        if (loot_type_match != _string_to_loot_type_map.end())
+        {
+            const LootType loot_type = loot_type_match->second;
+            LootFactory::make(loot_type, dude_position.x_center + offset_x, dude_position.y_center + offset_y);
+            return std::make_pair(true, "spawning");
+        }
+
+        return std::make_pair(true, "failed to match <NpcType/ItemType>");
+    });
+
+    _enter_command_handler = CommandHandler ([this](const Command& command){
+        if (command.size() != 2 && (command.at(0) == "HELP" || command.at(0) == "ENTER")) {
+            return std::make_pair(false, "enter <GameLoop::State>");
+        }
+
+        if (command.at(0) != "ENTER") {
+            return std::make_pair(false, "");
+        }
+
+        auto& registry = EntityRegistry::instance().get_registry();
+        auto cheat_consoles = registry.view<prefabs::CheatConsoleComponent>();
+        assert(cheat_consoles.size() == 1);
+        auto cheat_console = cheat_consoles.front();
+        auto& cheat_console_component = registry.get<prefabs::CheatConsoleComponent>(cheat_console);
+
+        const auto& requested_game_loop_state = command.at(1);
+        const auto game_loop_state_match = _string_to_game_loop_state_map.find(requested_game_loop_state);
+
+        if (game_loop_state_match == _string_to_game_loop_state_map.end())
+        {
+            return std::make_pair(true, "failed to match <GameLoopState>");
+        }
+
+        cheat_console_component.request_state_change(game_loop_state_match->second);
+        return std::make_pair(true, "entering");
+    });
+}
+
+const CheatConsoleInterpreter::CommandHandler& CheatConsoleInterpreter::get_spawn_command_handler() const
+{
+    return _spawn_command_handler;
+}
+
+const CheatConsoleInterpreter::CommandHandler& CheatConsoleInterpreter::get_enter_command_handler() const
+{
+    return _enter_command_handler;
+}

--- a/src/game-loop/src/other/ItemType.cpp
+++ b/src/game-loop/src/other/ItemType.cpp
@@ -1,0 +1,36 @@
+#include "other/ItemType.hpp"
+
+const char *to_string(ItemType item_type) {
+#define TO_STRING(x) case ItemType::x: return #x;
+    switch (item_type) {
+        TO_STRING(ARROW);
+        TO_STRING(BOMB);
+        TO_STRING(CAPE);
+        TO_STRING(CHEST);
+        TO_STRING(CRATE);
+        TO_STRING(JAR);
+        TO_STRING(JETPACK);
+        TO_STRING(PISTOL);
+        TO_STRING(ROCK);
+        TO_STRING(ROPE);
+        TO_STRING(SHOTGUN);
+        TO_STRING(SKULL);
+        TO_STRING(WHIP);
+        TO_STRING(BOMB_SPAWNER);
+        TO_STRING(ROPE_SPAWNER);
+        TO_STRING(WALLET);
+        TO_STRING(SPIKE_SHOES);
+        TO_STRING(SPRING_SHOES);
+        TO_STRING(MITT);
+        TO_STRING(GLOVE);
+        TO_STRING(COMPASS);
+        TO_STRING(BODY);
+        TO_STRING(BOMB_BAG);
+        TO_STRING(ROPE_PILE);
+        TO_STRING(GOLDEN_IDOL);
+        TO_STRING(FLARE);
+        TO_STRING(_SIZE);
+    }
+    assert(false);
+    return "Failed to match passed ItemType";
+}

--- a/src/game-loop/src/other/NpcType.cpp
+++ b/src/game-loop/src/other/NpcType.cpp
@@ -1,0 +1,19 @@
+#include "other/NpcType.hpp"
+
+const char *to_string(NpcType npc_type) {
+#define TO_STRING(x) case NpcType::x: return #x;
+    switch (npc_type) {
+        TO_STRING(NONE);
+        TO_STRING(SNAKE);
+        TO_STRING(BAT);
+        TO_STRING(CAVEMAN);
+        TO_STRING(SPIDER);
+        TO_STRING(SKELETON);
+        TO_STRING(SHOPKEEPER);
+        TO_STRING(DAMSEL);
+        TO_STRING(BLUE_FROG);
+        TO_STRING(RED_FROG);
+    }
+    assert(false);
+    return "Failed to match passed NpcType";
+}

--- a/src/game-loop/src/populator/ItemFactory.cpp
+++ b/src/game-loop/src/populator/ItemFactory.cpp
@@ -1,0 +1,64 @@
+#include "populator/ItemFactory.hpp"
+#include "EntityRegistry.hpp"
+#include "prefabs/items/Arrow.hpp"
+#include "components/generic/PositionComponent.hpp"
+#include "prefabs/items/Bomb.hpp"
+#include "prefabs/items/Cape.hpp"
+#include "prefabs/items/Chest.hpp"
+#include "prefabs/items/Crate.hpp"
+#include "prefabs/items/Jar.hpp"
+#include "prefabs/items/Jetpack.hpp"
+#include "prefabs/items/Pistol.hpp"
+#include "prefabs/items/Rock.hpp"
+#include "prefabs/items/Rope.hpp"
+#include "prefabs/items/Shotgun.hpp"
+#include "prefabs/items/Skull.hpp"
+#include "prefabs/items/Whip.hpp"
+#include "prefabs/items/SpikeShoes.hpp"
+#include "prefabs/items/SpringShoes.hpp"
+#include "prefabs/items/Mitt.hpp"
+#include "prefabs/items/Glove.hpp"
+#include "prefabs/items/Compass.hpp"
+#include "prefabs/items/BombBag.hpp"
+#include "prefabs/items/RopePile.hpp"
+#include "prefabs/items/GoldenIdol.hpp"
+#include "prefabs/items/Flare.hpp"
+
+entt::entity ItemFactory::make(ItemType item_type) {
+    switch (item_type)
+    {
+        case ItemType::ARROW: return prefabs::Arrow::create();
+        case ItemType::BOMB: return prefabs::Bomb::create();
+        case ItemType::CAPE: return prefabs::Cape::create();
+        case ItemType::CHEST: return prefabs::Chest::create();
+        case ItemType::CRATE: return prefabs::Crate::create();
+        case ItemType::JAR: return prefabs::Jar::create();
+        case ItemType::JETPACK: return prefabs::Jetpack::create();
+        case ItemType::PISTOL: return prefabs::Pistol::create();
+        case ItemType::ROCK: return prefabs::Rock::create();
+        case ItemType::ROPE: return prefabs::Rope::create();
+        case ItemType::SHOTGUN: return prefabs::Shotgun::create();
+        case ItemType::SKULL: return prefabs::Skull::create();
+        case ItemType::WHIP: return prefabs::Whip::create();
+        case ItemType::SPIKE_SHOES: return prefabs::SpikeShoes::create();
+        case ItemType::SPRING_SHOES: return prefabs::SpringShoes::create();
+        case ItemType::MITT: return prefabs::Mitt::create();
+        case ItemType::GLOVE: return prefabs::Glove::create();
+        case ItemType::COMPASS: return prefabs::Compass::create();
+        case ItemType::BOMB_BAG: return prefabs::BombBag::create();
+        case ItemType::ROPE_PILE: return prefabs::RopePile::create();
+        case ItemType::GOLDEN_IDOL: return prefabs::GoldenIdol::create();
+        case ItemType::FLARE: return prefabs::Flare::create();
+    }
+    assert(false);
+    return {};
+}
+
+entt::entity ItemFactory::make(ItemType item_type, float pos_x, float pos_y) {
+    const auto out_entity = make(item_type);
+    auto& registry = EntityRegistry::instance().get_registry();
+    auto& position = registry.get<PositionComponent>(out_entity);
+    position.x_center = pos_x;
+    position.y_center = pos_y;
+    return out_entity;
+}

--- a/src/game-loop/src/populator/LootFactory.cpp
+++ b/src/game-loop/src/populator/LootFactory.cpp
@@ -1,0 +1,24 @@
+#include "populator/LootFactory.hpp"
+#include "EntityRegistry.hpp"
+#include "components/generic/PositionComponent.hpp"
+
+entt::entity LootFactory::make(LootType loot_type) {
+    switch (loot_type)
+    {
+        case LootType::NOTHING:break;
+        case LootType::ANY:break;
+        case LootType::SHOP_ITEM:break;
+        case LootType::GOLDEN_IDOL:break;
+    }
+    assert(false);
+    return {};
+}
+
+entt::entity LootFactory::make(LootType loot_type, float pos_x, float pos_y) {
+    const auto out_entity = make(loot_type);
+    auto& registry = EntityRegistry::instance().get_registry();
+    auto& position = registry.get<PositionComponent>(out_entity);
+    position.x_center = pos_x;
+    position.y_center = pos_y;
+    return out_entity;
+}

--- a/src/game-loop/src/populator/NpcFactory.cpp
+++ b/src/game-loop/src/populator/NpcFactory.cpp
@@ -1,0 +1,37 @@
+#include "populator/NpcFactory.hpp"
+#include "EntityRegistry.hpp"
+#include "components/generic/PositionComponent.hpp"
+#include "prefabs/npc/Snake.hpp"
+#include "prefabs/npc/Bat.hpp"
+#include "prefabs/npc/Caveman.hpp"
+#include "prefabs/npc/Spider.hpp"
+#include "prefabs/npc/Skeleton.hpp"
+#include "prefabs/npc/Shopkeeper.hpp"
+#include "prefabs/npc/Damsel.hpp"
+#include "prefabs/npc/BlueFrog.hpp"
+#include "prefabs/npc/RedFrog.hpp"
+
+entt::entity NpcFactory::make(NpcType npc_type) {
+    switch (npc_type)
+    {
+        case NpcType::SNAKE: return prefabs::Snake::create();
+        case NpcType::BAT: return prefabs::Bat::create();
+        case NpcType::CAVEMAN: return prefabs::Caveman::create();
+        case NpcType::SPIDER: return prefabs::Spider::create();
+        case NpcType::SKELETON: return prefabs::Skeleton::create();
+        case NpcType::SHOPKEEPER: return prefabs::Shopkeeper::create();
+        case NpcType::BLUE_FROG: return prefabs::BlueFrog::create();
+        case NpcType::RED_FROG: return prefabs::RedFrog::create();
+    }
+    assert(false);
+    return {};
+}
+
+entt::entity NpcFactory::make(NpcType npc_type, float pos_x, float pos_y) {
+    const auto out_entity = make(npc_type);
+    auto& registry = EntityRegistry::instance().get_registry();
+    auto& position = registry.get<PositionComponent>(out_entity);
+    position.x_center = pos_x;
+    position.y_center = pos_y;
+    return out_entity;
+}

--- a/src/game-loop/src/populator/Populator.cpp
+++ b/src/game-loop/src/populator/Populator.cpp
@@ -59,6 +59,8 @@ void Populator::generate_inventory_items(entt::entity main_dude)
     {
         entt::entity item = entt::null;
 
+        // TODO: ItemFactory, NpcFactory, LootFactory that takes an enum  
+
         switch (item_type)
         {
             case ItemType::ARROW: item = prefabs::Arrow::create(); break;

--- a/src/game-loop/src/populator/Populator.cpp
+++ b/src/game-loop/src/populator/Populator.cpp
@@ -59,8 +59,6 @@ void Populator::generate_inventory_items(entt::entity main_dude)
     {
         entt::entity item = entt::null;
 
-        // TODO: ItemFactory, NpcFactory, LootFactory that takes an enum  
-
         switch (item_type)
         {
             case ItemType::ARROW: item = prefabs::Arrow::create(); break;

--- a/src/game-loop/src/prefabs/ui/CheatConsole.cpp
+++ b/src/game-loop/src/prefabs/ui/CheatConsole.cpp
@@ -237,22 +237,22 @@ namespace {
                 if (upper_cased == "ENTER SCORES") {
                     auto& registry = EntityRegistry::instance().get_registry();
                     auto& cheat_console_component = registry.get<prefabs::CheatConsoleComponent>(_self);
-                    cheat_console_component.state = GameLoop::State::SCORES;
+                    cheat_console_component.request_state_change(GameLoop::State::SCORES);
                     return std::make_pair(true, "entering scores");
                 } else if (upper_cased == "ENTER MAIN_MENU") {
                     auto& registry = EntityRegistry::instance().get_registry();
                     auto& cheat_console_component = registry.get<prefabs::CheatConsoleComponent>(_self);
-                    cheat_console_component.state = GameLoop::State::MAIN_MENU;
+                    cheat_console_component.request_state_change(GameLoop::State::MAIN_MENU);
                     return std::make_pair(true, "entering main_menu");
                 } else if (upper_cased == "ENTER SANDBOX") {
                     auto& registry = EntityRegistry::instance().get_registry();
                     auto& cheat_console_component = registry.get<prefabs::CheatConsoleComponent>(_self);
-                    cheat_console_component.state = GameLoop::State::SANDBOX;
+                    cheat_console_component.request_state_change(GameLoop::State::SANDBOX);
                     return std::make_pair(true, "entering sanbox");
                 } else if (upper_cased == "ENTER PLAYING") {
                     auto& registry = EntityRegistry::instance().get_registry();
                     auto& cheat_console_component = registry.get<prefabs::CheatConsoleComponent>(_self);
-                    cheat_console_component.state = GameLoop::State::PLAYING;
+                    cheat_console_component.request_state_change(GameLoop::State::PLAYING);
                     return std::make_pair(true, "entering playing");
                 } else {
                     return std::make_pair(false, "");

--- a/src/game-loop/src/prefabs/ui/CheatConsole.cpp
+++ b/src/game-loop/src/prefabs/ui/CheatConsole.cpp
@@ -3,12 +3,15 @@
 #include "components/generic/ScriptingComponent.hpp"
 #include "components/generic/ImguiComponent.hpp"
 #include "logger/log.h"
-#include "imgui_impl_opengl2.h"
-#include "imgui_impl_sdl2.h"
 #include "Input.hpp"
 #include "prefabs/npc/RedFrog.hpp"
 #include "components/specialized/MainDudeComponent.hpp"
 #include "game-loop/GameLoop.hpp"
+
+// TODO: Better way to handle this than if-defing as there will be more imgui-components
+#if defined(SPELUNKY_PSP_WITH_IMGUI)
+#include "imgui_impl_opengl2.h"
+#include "imgui_impl_sdl2.h"
 
 namespace {
     // Based on ImGui's example console:
@@ -309,6 +312,13 @@ namespace {
         const std::function<void()> dont_render_callback = [](){};
     };
 }
+#else
+class CheatConsoleScript final : public ScriptBase {
+    public:
+        explicit CheatConsoleScript(entt::entity self) { }
+        void update(entt::entity owner, uint32_t delta_time_ms) override { }
+};
+#endif
 
 namespace prefabs {
 

--- a/src/game-loop/src/prefabs/ui/CheatConsole.cpp
+++ b/src/game-loop/src/prefabs/ui/CheatConsole.cpp
@@ -244,6 +244,11 @@ namespace {
                     auto& cheat_console_component = registry.get<prefabs::CheatConsoleComponent>(_self);
                     cheat_console_component.state = GameLoop::State::MAIN_MENU;
                     return std::make_pair(true, "entering main_menu");
+                } else if (upper_cased == "ENTER SANDBOX") {
+                    auto& registry = EntityRegistry::instance().get_registry();
+                    auto& cheat_console_component = registry.get<prefabs::CheatConsoleComponent>(_self);
+                    cheat_console_component.state = GameLoop::State::SANDBOX;
+                    return std::make_pair(true, "entering sanbox");
                 } else if (upper_cased == "ENTER PLAYING") {
                     auto& registry = EntityRegistry::instance().get_registry();
                     auto& cheat_console_component = registry.get<prefabs::CheatConsoleComponent>(_self);

--- a/src/game-loop/src/prefabs/ui/CheatConsole.cpp
+++ b/src/game-loop/src/prefabs/ui/CheatConsole.cpp
@@ -1,0 +1,59 @@
+#include "prefabs/ui/CheatConsole.hpp"
+#include "EntityRegistry.hpp"
+#include "components/generic/ScriptingComponent.hpp"
+#include "components/generic/ImguiComponent.hpp"
+#include "logger/log.h"
+#include "imgui_impl_opengl2.h"
+#include "imgui_impl_sdl2.h"
+#include "Input.hpp"
+
+namespace {
+    class CheatConsoleScript final : public ScriptBase {
+    public:
+
+        explicit CheatConsoleScript(entt::entity self) : _self(self) {}
+
+        void update(entt::entity owner, uint32_t delta_time_ms) override {
+            auto &registry = EntityRegistry::instance().get_registry();
+            auto& input = Input::instance();
+
+            if (input.cheat_console().changed() && input.cheat_console().value()) {
+                _visible = !_visible;
+
+                auto& imgui_component = registry.get<ImguiComponent>(_self);
+                if (_visible) {
+                    imgui_component.render_callback = &render_window;
+                } else {
+                    imgui_component.render_callback = &dont_render_window;
+                }
+            }
+        }
+    private:
+        bool _visible = false;
+        entt::entity _self;
+
+        static void render_window() {
+            bool show_another_window;
+            ImGui::Begin("Cheat console", &show_another_window);
+            ImGui::Text("This will work soon ;)");
+            ImGui::End();
+        }
+        static void dont_render_window() {}
+    };
+}
+namespace prefabs {
+
+    entt::entity CheatConsole::create(const std::shared_ptr<Viewport> &viewport) {
+        auto &registry = EntityRegistry::instance().get_registry();
+
+        const auto entity = registry.create();
+        auto cheat_console_script = std::make_shared<CheatConsoleScript>(entity);
+        ScriptingComponent scripting_component(cheat_console_script);
+        registry.emplace<ScriptingComponent>(entity, scripting_component);
+
+        ImguiComponent imgui_component;
+        imgui_component.render_callback = [](){};
+        registry.emplace<ImguiComponent>(entity, imgui_component);
+        return entity;
+    }
+}

--- a/src/game-loop/src/prefabs/ui/CheatConsole.cpp
+++ b/src/game-loop/src/prefabs/ui/CheatConsole.cpp
@@ -6,41 +6,305 @@
 #include "imgui_impl_opengl2.h"
 #include "imgui_impl_sdl2.h"
 #include "Input.hpp"
+#include "prefabs/npc/RedFrog.hpp"
+#include "components/specialized/MainDudeComponent.hpp"
+#include "game-loop/GameLoop.hpp"
 
 namespace {
+    // Based on ImGui's example console:
+    static int Stricmp(const char *s1, const char *s2) {
+        int d;
+        while ((d = toupper(*s2) - toupper(*s1)) == 0 && *s1) {
+            s1++;
+            s2++;
+        }
+        return d;
+    }
+
+    static char *Strdup(const char *s) {
+        IM_ASSERT(s);
+        size_t len = strlen(s) + 1;
+        void *buf = malloc(len);
+        IM_ASSERT(buf);
+        return (char *) memcpy(buf, (const void *) s, len);
+    }
+
+    static void Strtrim(char *s) {
+        char *str_end = s + strlen(s);
+        while (str_end > s && str_end[-1] == ' ') str_end--;
+        *str_end = 0;
+    }
+
+    using Command = std::string;
+    using CommandHandlerResult = std::pair<bool, std::string>;
+    using CommandHandler = std::function<CommandHandlerResult(const Command&)>;
+
+    struct ImGuiConsole {
+        char InputBuf[256];
+        ImVector<char *> Items;
+        ImVector<const char *> Commands;
+        ImVector<char *> History;
+        ImGuiTextFilter Filter;
+        bool AutoScroll;
+        bool ScrollToBottom;
+
+        std::vector<CommandHandler> _command_handlers;
+        
+        void add_command_handler(const CommandHandler& command_handler) {
+            _command_handlers.push_back(command_handler);    
+        }
+        
+        ImGuiConsole() {
+            ClearLog();
+            memset(InputBuf, 0, sizeof(InputBuf));
+            // "CLASSIFY" is here to provide the test case where "C"+[tab] completes to "CL" and display multiple matches.
+            Commands.push_back("HELP");
+            Commands.push_back("HISTORY");
+            Commands.push_back("CLEAR");
+            Commands.push_back("CLASSIFY");
+            AutoScroll = true;
+            ScrollToBottom = false;
+        }
+
+        ~ImGuiConsole() {
+            ClearLog();
+            for (int i = 0; i < History.Size; i++)
+                free(History[i]);
+        }
+
+        void ClearLog() {
+            for (int i = 0; i < Items.Size; i++)
+                free(Items[i]);
+            Items.clear();
+        }
+
+        void AddLog(const char *fmt, ...) IM_FMTARGS(2) {
+            // FIXME-OPT
+            char buf[1024];
+            va_list args;
+            va_start(args, fmt);
+            vsnprintf(buf, IM_ARRAYSIZE(buf), fmt, args);
+            buf[IM_ARRAYSIZE(buf) - 1] = 0;
+            va_end(args);
+            Items.push_back(Strdup(buf));
+        }
+
+        void Draw(const char *title, bool *p_open) {
+            ImGui::SetNextWindowSize(ImVec2(520, 600), ImGuiCond_FirstUseEver);
+            if (!ImGui::Begin(title, p_open)) {
+                ImGui::End();
+                return;
+            }
+
+            if (ImGui::BeginPopupContextItem()) {
+                if (ImGui::MenuItem("Close Console"))
+                    *p_open = false;
+                ImGui::EndPopup();
+            }
+
+            ImGui::Separator();
+            ImGui::SetWindowFontScale(2.0f);
+
+            // Reserve enough left-over height for 1 separator + 1 input text
+            const float footer_height_to_reserve = ImGui::GetStyle().ItemSpacing.y + ImGui::GetFrameHeightWithSpacing();
+            if (ImGui::BeginChild("ScrollingRegion", ImVec2(0, -footer_height_to_reserve), ImGuiChildFlags_None, ImGuiWindowFlags_HorizontalScrollbar)) {
+                if (ImGui::BeginPopupContextWindow()) {
+                    if (ImGui::Selectable("Clear")) ClearLog();
+                    ImGui::EndPopup();
+                }
+
+                ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(4, 1)); // Tighten spacing
+                for (const char *item: Items) {
+                    if (!Filter.PassFilter(item))
+                        continue;
+
+                    // Normally you would store more information in your item than just a string.
+                    // (e.g. make Items[] an array of structure, store color/type etc.)
+                    ImVec4 color;
+                    bool has_color = false;
+                    if (strstr(item, "[error]")) {
+                        color = ImVec4(1.0f, 0.4f, 0.4f, 1.0f);
+                        has_color = true;
+                    } else if (strncmp(item, "# ", 2) == 0) {
+                        color = ImVec4(1.0f, 0.8f, 0.6f, 1.0f);
+                        has_color = true;
+                    }
+                    if (has_color)
+                        ImGui::PushStyleColor(ImGuiCol_Text, color);
+                    ImGui::TextUnformatted(item);
+                    if (has_color)
+                        ImGui::PopStyleColor();
+                }
+
+                // Keep up at the bottom of the scroll region if we were already at the bottom at the beginning of the frame.
+                // Using a scrollbar or mouse-wheel will take away from the bottom edge.
+                if (ScrollToBottom || (AutoScroll && ImGui::GetScrollY() >= ImGui::GetScrollMaxY()))
+                    ImGui::SetScrollHereY(1.0f);
+                ScrollToBottom = false;
+
+                ImGui::PopStyleVar();
+            }
+            ImGui::EndChild();
+            ImGui::Separator();
+
+            // Command-line
+            bool reclaim_focus = false;
+            ImGuiInputTextFlags input_text_flags =
+                    ImGuiInputTextFlags_EnterReturnsTrue | ImGuiInputTextFlags_EscapeClearsAll;
+            ImGui::SetKeyboardFocusHere(0); // Added
+            if (ImGui::InputText("Input", InputBuf, IM_ARRAYSIZE(InputBuf), input_text_flags, nullptr, (void *) this)) {
+                char *s = InputBuf;
+                Strtrim(s);
+                if (s[0])
+                    ExecCommand(s);
+                strcpy(s, "");
+                reclaim_focus = true;
+            }
+
+            // Auto-focus on window apparition
+            ImGui::SetItemDefaultFocus();
+            if (reclaim_focus)
+                ImGui::SetKeyboardFocusHere(-1); // Auto focus previous widget
+
+            ImGui::End();
+        }
+
+        void ExecCommand(const char *command_line) {
+            AddLog("# %s\n", command_line);
+
+            // Insert into history. First find match and delete it so it can be pushed to the back.
+            // This isn't trying to be smart or optimal.
+            for (int i = History.Size - 1; i >= 0; i--) {
+                if (Stricmp(History[i], command_line) == 0) {
+                    free(History[i]);
+                    History.erase(History.begin() + i);
+                    break;
+                }
+            }
+            History.push_back(Strdup(command_line));
+
+            // Process command
+            bool handled = false;
+            for (auto& handler : _command_handlers) {
+                const auto result = handler(command_line);
+                if (result.first)
+                {
+                    handled = true;
+                    AddLog(result.second.c_str());
+                    break;
+                }
+            }
+
+            if (handled) {
+                // ...
+            }
+            else if (Stricmp(command_line, "CLEAR") == 0) {
+                ClearLog();
+            } else if (Stricmp(command_line, "HELP") == 0) {
+                AddLog("Commands:");
+                for (int i = 0; i < Commands.Size; i++) {
+                    AddLog("- %s", Commands[i]);
+                }
+            } else if (Stricmp(command_line, "HISTORY") == 0) {
+                int first = History.Size - 10;
+                for (int i = first > 0 ? first : 0; i < History.Size; i++) {
+                    AddLog("%3d: %s\n", i, History[i]);
+                }
+            } else {
+                AddLog("Unknown command: '%s'\n", command_line);
+            }
+
+            // On command input, we scroll to bottom even if AutoScroll==false
+            ScrollToBottom = true;
+        }
+    };
     class CheatConsoleScript final : public ScriptBase {
     public:
+        explicit CheatConsoleScript(entt::entity self) : _self(self) {
+            // TODO: Helper for splitting into tokens
+            _imgui_console.add_command_handler([](const Command& command){
+                Command upper_cased;
+                std::transform(command.cbegin(), command.cend(), std::back_inserter(upper_cased), [](char c){ return std::toupper(c);});
+                if (upper_cased == "EXIT") {
+                    return std::make_pair(true, "exiting");
+                } else {
+                    return std::make_pair(false, "");
+                }
+            });
+            _imgui_console.add_command_handler([this](const Command& command){
+                Command upper_cased;
+                std::transform(command.cbegin(), command.cend(), std::back_inserter(upper_cased), [](char c){ return std::toupper(c);});
+                if (upper_cased == "ENTER SCORES") {
+                    auto& registry = EntityRegistry::instance().get_registry();
+                    auto& cheat_console_component = registry.get<prefabs::CheatConsoleComponent>(_self);
+                    cheat_console_component.state = GameLoop::State::SCORES;
+                    return std::make_pair(true, "entering scores");
+                } else if (upper_cased == "ENTER MAIN_MENU") {
+                    auto& registry = EntityRegistry::instance().get_registry();
+                    auto& cheat_console_component = registry.get<prefabs::CheatConsoleComponent>(_self);
+                    cheat_console_component.state = GameLoop::State::MAIN_MENU;
+                    return std::make_pair(true, "entering main_menu");
+                } else if (upper_cased == "ENTER PLAYING") {
+                    auto& registry = EntityRegistry::instance().get_registry();
+                    auto& cheat_console_component = registry.get<prefabs::CheatConsoleComponent>(_self);
+                    cheat_console_component.state = GameLoop::State::PLAYING;
+                    return std::make_pair(true, "entering playing");
+                } else {
+                    return std::make_pair(false, "");
+                }
+            });
+            _imgui_console.add_command_handler([](const Command& command){
+                Command upper_cased;
+                std::transform(command.cbegin(), command.cend(), std::back_inserter(upper_cased), [](char c){ return std::toupper(c);});
+                if (upper_cased == "SPAWN REDFROG") {
 
-        explicit CheatConsoleScript(entt::entity self) : _self(self) {}
+                    auto& registry = EntityRegistry::instance().get_registry();
+                    auto dudes = registry.view<MainDudeComponent>();
+                    assert(dudes.size() == 1);
+                    auto dude = dudes.front();
+                    auto &dude_position = registry.get<PositionComponent>(dude);
+
+                    const float pos_x = dude_position.x_center - 2;
+                    const float pos_y = dude_position.y_center - 2;
+                    prefabs::RedFrog::create(pos_x, pos_y);
+
+                    return std::make_pair(true, "spawning");
+                } else {
+                    return std::make_pair(false, "");
+                }
+            });
+        }
 
         void update(entt::entity owner, uint32_t delta_time_ms) override {
             auto &registry = EntityRegistry::instance().get_registry();
-            auto& input = Input::instance();
-
+            auto &input = Input::instance();
             if (input.cheat_console().changed() && input.cheat_console().value()) {
                 _visible = !_visible;
-
-                auto& imgui_component = registry.get<ImguiComponent>(_self);
+                auto &imgui_component = registry.get<ImguiComponent>(_self);
                 if (_visible) {
-                    imgui_component.render_callback = &render_window;
+                    imgui_component.render_callback = render_console_callback;
                 } else {
-                    imgui_component.render_callback = &dont_render_window;
+                    imgui_component.render_callback = dont_render_callback;
                 }
             }
         }
-    private:
-        bool _visible = false;
-        entt::entity _self;
 
-        static void render_window() {
-            bool show_another_window;
-            ImGui::Begin("Cheat console", &show_another_window);
-            ImGui::Text("This will work soon ;)");
-            ImGui::End();
-        }
-        static void dont_render_window() {}
+    private:
+        // Returns commands, i.e <SPAWN, REDFROG>
+        //                   i.e <ENTER, SCORES>
+        // To be interpreted later
+
+        entt::entity _self;
+        ImGuiConsole _imgui_console;
+        bool _visible = false;
+        const std::function<void()> render_console_callback = [this](){
+            bool dummy = false;
+            _imgui_console.Draw("Cheat console", &dummy);
+        };
+        const std::function<void()> dont_render_callback = [](){};
     };
 }
+
 namespace prefabs {
 
     entt::entity CheatConsole::create(const std::shared_ptr<Viewport> &viewport) {
@@ -48,12 +312,14 @@ namespace prefabs {
 
         const auto entity = registry.create();
         auto cheat_console_script = std::make_shared<CheatConsoleScript>(entity);
+        CheatConsoleComponent cheat_console_component{};
         ScriptingComponent scripting_component(cheat_console_script);
         registry.emplace<ScriptingComponent>(entity, scripting_component);
 
         ImguiComponent imgui_component;
         imgui_component.render_callback = [](){};
         registry.emplace<ImguiComponent>(entity, imgui_component);
+        registry.emplace<CheatConsoleComponent>(entity, cheat_console_component);
         return entity;
     }
 }

--- a/src/game-loop/src/system/RenderingSystem.cpp
+++ b/src/game-loop/src/system/RenderingSystem.cpp
@@ -7,8 +7,6 @@
 #include "components/generic/QuadComponent.hpp"
 #include "components/generic/MeshComponent.hpp"
 #include "components/generic/BlinkingComponent.hpp"
-#include "imgui_impl_opengl2.h"
-#include "imgui_impl_sdl2.h"
 #include "components/generic/ImguiComponent.hpp"
 
 void RenderingSystem::update(std::uint32_t delta_time_ms)
@@ -141,6 +139,10 @@ void RenderingSystem::update_opengl(std::uint32_t delta_time_ms) {
     });
 }
 
+#if defined(SPELUNKY_PSP_WITH_IMGUI)
+#include "imgui_impl_opengl2.h"
+#include "imgui_impl_sdl2.h"
+
 void RenderingSystem::update_imgui() {
 
     ImGui_ImplOpenGL2_NewFrame();
@@ -161,3 +163,6 @@ void RenderingSystem::update_imgui() {
         ImGui_ImplOpenGL2_RenderDrawData(draw_data);
     }
 }
+#else
+void RenderingSystem::update_imgui() {}
+#endif

--- a/src/input/CMakeLists.txt
+++ b/src/input/CMakeLists.txt
@@ -31,5 +31,6 @@ target_link_libraries(Input
         $<$<BOOL:${SPELUNKY_PSP_PLATFORM_LINUX}>:SDL_2_XX>
         $<$<BOOL:${SPELUNKY_PSP_PLATFORM_WINDOWS}>:SDL_1_XX>
         $<$<BOOL:${SPELUNKY_PSP_PLATFORM_PSP}>:SDL_1_XX>
-        $<$<BOOL:${SPELUNKY_PSP_PLATFORM_DESKTOP}>:imgui>
+        $<$<BOOL:${SPELUNKY_PSP_WITH_IMGUI}>:imgui>
+        Dependencies
 )

--- a/src/input/CMakeLists.txt
+++ b/src/input/CMakeLists.txt
@@ -31,4 +31,5 @@ target_link_libraries(Input
         $<$<BOOL:${SPELUNKY_PSP_PLATFORM_LINUX}>:SDL_2_XX>
         $<$<BOOL:${SPELUNKY_PSP_PLATFORM_WINDOWS}>:SDL_1_XX>
         $<$<BOOL:${SPELUNKY_PSP_PLATFORM_PSP}>:SDL_1_XX>
+        $<$<BOOL:${SPELUNKY_PSP_PLATFORM_DESKTOP}>:imgui>
 )

--- a/src/input/interface/Input.hpp
+++ b/src/input/interface/Input.hpp
@@ -36,6 +36,7 @@ public:
     inline const Toggle& out_bomb() const { return _toggles.out_bomb; }
     inline const Toggle& out_rope() const { return _toggles.out_rope; }
     inline const Toggle& purchase() const { return _toggles.purchase; }
+    inline const Toggle& cheat_console() const { return _toggles.cheat_console; }
 
     inline const std::vector<InputEvent>& get_input_events() const { return _input_events; }
 
@@ -60,6 +61,7 @@ private:
         Toggle out_bomb{false};
         Toggle out_rope{false};
         Toggle purchase{false};
+        Toggle cheat_console{false};
     } _toggles;
 
     std::vector<InputEvent> _input_events;

--- a/src/input/src/Input_Desktop.cpp
+++ b/src/input/src/Input_Desktop.cpp
@@ -1,6 +1,7 @@
 #include "Input.hpp"
 
 #include <SDL2/SDL_events.h>
+#include "imgui_impl_sdl2.h"
 
 const char* Input::get_pause_binding_msg()
 {
@@ -45,16 +46,17 @@ void Input::poll()
     _toggles.out_bomb.reset_changed();
     _toggles.out_rope.reset_changed();
     _toggles.purchase.reset_changed();
+    _toggles.cheat_console.reset_changed();
 
     SDL_Event event{};
 
     while (SDL_PollEvent(&event))
     {
+        ImGui_ImplSDL2_ProcessEvent(&event);
         if (event.type == SDL_EventType::SDL_KEYDOWN || event.type == SDL_EventType::SDL_KEYUP)
         {
             const auto& key = event.key.keysym.sym;
             const bool v = event.type == SDL_EventType::SDL_KEYDOWN;
-
             if (key == SDLK_LEFT)
             {
                 _toggles.left.feed(v);
@@ -110,6 +112,10 @@ void Input::poll()
             else if (key == SDLK_F10)
             {
                 _toggles.quit_requested.feed(v);
+            }
+            else if (key == SDLK_TAB)
+            {
+                _toggles.cheat_console.feed(v);
             }
         }
     }

--- a/src/input/src/Input_Desktop.cpp
+++ b/src/input/src/Input_Desktop.cpp
@@ -1,7 +1,14 @@
 #include "Input.hpp"
 
 #include <SDL2/SDL_events.h>
-#include "imgui_impl_sdl2.h"
+
+#if defined(SPELUNKY_PSP_WITH_IMGUI)
+    #include "imgui_impl_sdl2.h"
+    void imgui_event_processing(const SDL_Event* event) { ImGui_ImplSDL2_ProcessEvent(event); }
+#else
+    void imgui_event_processing(const SDL_Event* event) {}
+#endif
+
 
 const char* Input::get_pause_binding_msg()
 {
@@ -52,7 +59,7 @@ void Input::poll()
 
     while (SDL_PollEvent(&event))
     {
-        ImGui_ImplSDL2_ProcessEvent(&event);
+        imgui_event_processing(&event);
         if (event.type == SDL_EventType::SDL_KEYDOWN || event.type == SDL_EventType::SDL_KEYUP)
         {
             const auto& key = event.key.keysym.sym;

--- a/src/level/CMakeLists.txt
+++ b/src/level/CMakeLists.txt
@@ -21,7 +21,7 @@ add_library(Level STATIC
         include/ShopRooms.hpp
         include/SplashScreenRooms.hpp
         interface/NPCType.hpp
-        )
+        src/LootType.cpp)
 
 target_include_directories(Level
         PRIVATE include interface

--- a/src/level/CMakeLists.txt
+++ b/src/level/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(Level STATIC
         src/Level.cpp
         src/MapTile.cpp
         src/TileBatch.cpp
+        src/LootType.cpp
         interface/Level.hpp
         interface/MapTile.hpp
         interface/MapTileType.hpp
@@ -21,7 +22,7 @@ add_library(Level STATIC
         include/ShopRooms.hpp
         include/SplashScreenRooms.hpp
         interface/NPCType.hpp
-        src/LootType.cpp)
+        )
 
 target_include_directories(Level
         PRIVATE include interface

--- a/src/level/interface/LootType.hpp
+++ b/src/level/interface/LootType.hpp
@@ -2,10 +2,14 @@
 
 #include <cstdint>
 
-enum class LootType : std::uint16_t
+using LootType_t = std::uint16_t;
+enum class LootType : LootType_t // FIXME
 {
     NOTHING = 0,
     ANY = 1,
     SHOP_ITEM = 2,
-    GOLDEN_IDOL = 3
+    GOLDEN_IDOL = 3,
+    _SIZE = 4
 };
+
+const char* to_string(LootType);

--- a/src/level/interface/LootType.hpp
+++ b/src/level/interface/LootType.hpp
@@ -3,8 +3,9 @@
 #include <cstdint>
 
 using LootType_t = std::uint16_t;
-enum class LootType : LootType_t // FIXME
+enum class LootType : LootType_t
 {
+    // FIXME: Does not represent all types of loot
     NOTHING = 0,
     ANY = 1,
     SHOP_ITEM = 2,

--- a/src/level/interface/TileBatch.hpp
+++ b/src/level/interface/TileBatch.hpp
@@ -74,6 +74,8 @@ public:
 
     RoomType get_room_type_at(int x_room, int y_room) const;
 
+    void clean();
+
 private:
 
     // Any encountered closed room will be turned into an altar.

--- a/src/level/src/LootType.cpp
+++ b/src/level/src/LootType.cpp
@@ -1,0 +1,15 @@
+#include "LootType.hpp"
+#include <cassert>
+
+const char *to_string(LootType loot_type) {
+#define TO_STRING(x) case LootType::x: return #x;
+    switch (loot_type) {
+        TO_STRING(NOTHING);
+        TO_STRING(ANY);
+        TO_STRING(SHOP_ITEM);
+        TO_STRING(GOLDEN_IDOL);
+        TO_STRING(_SIZE);
+    }
+    assert(false);
+    return "Failed to match passed LootType";
+}

--- a/src/level/src/TileBatch.cpp
+++ b/src/level/src/TileBatch.cpp
@@ -672,3 +672,14 @@ RoomType TileBatch::get_room_type_at(int x_room, int y_room) const
     y_room = std::abs(y_room - (ROOMS_COUNT_HEIGHT - 1));
     return _layout[x_room][y_room];
 }
+
+void TileBatch::clean() {
+    for (int x = 0; x < LEVEL_WIDTH_TILES; x++) {
+        for (int y = 0; y < LEVEL_HEIGHT_TILES; y++) {
+            map_tiles[x][y]->match_tile(MapTileType::NOTHING);
+            map_tiles[x][y]->destroyable = false;
+            map_tiles[x][y]->x = x;
+            map_tiles[x][y]->y = y;
+        }
+    }
+}

--- a/src/texture-bank/CMakeLists.txt
+++ b/src/texture-bank/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(TextureBank STATIC
         interface/spritesheet-frames/MainDudeSpritesheetFrames.hpp
         interface/spritesheet-frames/FontSpritesheetFrames.hpp
         interface/spritesheet-frames/NPCSpritesheetFrames.hpp
-        )
+        interface/spritesheet-frames/CaveLevelSpritesheetFrames.hpp)
 
 target_include_directories(TextureBank
         PRIVATE include interface

--- a/src/texture-bank/CMakeLists.txt
+++ b/src/texture-bank/CMakeLists.txt
@@ -13,7 +13,8 @@ add_library(TextureBank STATIC
         interface/spritesheet-frames/MainDudeSpritesheetFrames.hpp
         interface/spritesheet-frames/FontSpritesheetFrames.hpp
         interface/spritesheet-frames/NPCSpritesheetFrames.hpp
-        interface/spritesheet-frames/CaveLevelSpritesheetFrames.hpp)
+        interface/spritesheet-frames/CaveLevelSpritesheetFrames.hpp
+        )
 
 target_include_directories(TextureBank
         PRIVATE include interface

--- a/src/texture-bank/interface/spritesheet-frames/CaveLevelSpritesheetFrames.hpp
+++ b/src/texture-bank/interface/spritesheet-frames/CaveLevelSpritesheetFrames.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <cstdint>
+
+enum class CaveLevelSpritesheetFrames : std::uint32_t {
+    NOTHING = 0,                    // 0 NON_COLLIDABLE
+    CAVE_ROCK,                      // 1
+    CAVE_REGULAR,                   // 2
+    STONE_BLOCK,                    // 3
+    CAVE_DOWN_ORIENTED,             // 4
+    CAVE_SOME_GOLD,                 // 5
+    CAVE_MUCH_GOLD,                 // 6
+    CAVE_UP_ORIENTED,               // 7
+    CAVE_UP_DOWN_ORIENTED,          // 8
+    LADDER,                         // 9  NON_COLLIDABLE
+    LADDER_DECK,                    // 10 NON_COLLIDABLE
+    ARROW_TRAP_LEFT,                // 11
+    ARROW_TRAP_RIGHT,               // 12
+    ENTRANCE,                       // 13 NON_COLLIDABLE
+    EXIT,                           // 14 NON_COLLIDABLE
+    CONSOLE_LEFT_BAR_TOP_ROUNDED,   // 15
+    CONSOLE_RIGHT_BAR_TOP_ROUNDED,  // 16
+    CONSOLE_LEFT_BAR_BOT_ROUNDED,   // 17
+    CONSOLE_RIGHT_BAR_BOT_ROUNDED,  // 18
+    CONSOLE_TOP_BAR,                // 19
+    CONSOLE_BOTTOM_BAR,             // 20
+    CONSOLE_LEFT_BAR,               // 21
+    CONSOLE_RIGHT_BAR,              // 22
+    CONSOLE_BLACK_BACKGROUND,       // 23
+    CAVE_SMOOTH,                    // 24
+    SCORES_STAR_DOOR,               // 25
+    SCORES_SUN_DOOR,                // 26
+    SCORES_MOON_DOOR,               // 27
+    SCORES_CHANGING_DOOR,           // 28
+    SHOP_SIGN_RARE,                 // 29
+    SHOP_SIGN_WEAPON,               // 30
+    SHOP_SIGN_BOMBS,                // 31
+    SHOP_SIGN_CLOTHING,             // 32
+    SHOP_SIGN_CRAPS,                // 33
+    SHOP_SIGN_GENERAL,              // 34
+    SHOP_SIGN_KISSING,              // 35
+    NA,                             // 36
+    SHOP_MUGSHOT_1,                 // 37
+    SHOP_MUGSHOT_2,                 // 38
+    SHOP_MUGSHOT_3,                 // 39
+    SHOP_MUGSHOT_4,                 // 40
+    ALTAR_LEFT,                     // 41
+    ALTAR_RIGHT,                    // 42
+    CAVE_BG_1,                      // 43
+    CAVE_BG_2,                      // 44
+    CAVE_BG_3,                      // 45
+    CAVE_BG_4,                      // 46
+    _SIZE                           // 47 Total elements
+};

--- a/src/video/CMakeLists.txt
+++ b/src/video/CMakeLists.txt
@@ -34,5 +34,6 @@ target_link_libraries(Video
         $<IF:$<BOOL:${SPELUNKY_PSP_PLATFORM_LINUX}>,SDL_2_XX,>
         $<IF:$<BOOL:${SPELUNKY_PSP_PLATFORM_DARWIN}>,SDL_2_XX,>
         $<IF:$<BOOL:${SPELUNKY_PSP_PLATFORM_ANDROID}>,SDL_2_XX,>
-        $<IF:$<BOOL:${SPELUNKY_PSP_PLATFORM_DESKTOP}>,imgui,>
+        $<IF:$<BOOL:${SPELUNKY_PSP_WITH_IMGUI}>,imgui,>
+        Dependencies
 )

--- a/src/video/CMakeLists.txt
+++ b/src/video/CMakeLists.txt
@@ -34,4 +34,5 @@ target_link_libraries(Video
         $<IF:$<BOOL:${SPELUNKY_PSP_PLATFORM_LINUX}>,SDL_2_XX,>
         $<IF:$<BOOL:${SPELUNKY_PSP_PLATFORM_DARWIN}>,SDL_2_XX,>
         $<IF:$<BOOL:${SPELUNKY_PSP_PLATFORM_ANDROID}>,SDL_2_XX,>
+        $<IF:$<BOOL:${SPELUNKY_PSP_PLATFORM_DESKTOP}>,imgui,>
 )

--- a/src/video/src/Video_Desktop.cpp
+++ b/src/video/src/Video_Desktop.cpp
@@ -90,7 +90,7 @@ bool Video::setup_gl()
     _platform_specific->window = SDL_CreateWindow("SpelunkyPSP",
                               SDL_WINDOWPOS_UNDEFINED,
                               SDL_WINDOWPOS_UNDEFINED,
-                              480 * 2, 272 * 2,
+                              480 * 4, 272 * 4,
                               SDL_WINDOW_OPENGL |
                               SDL_WINDOW_ALLOW_HIGHDPI);
     if (!_platform_specific->window)

--- a/src/video/src/Video_Desktop.cpp
+++ b/src/video/src/Video_Desktop.cpp
@@ -8,6 +8,7 @@
 #include <SDL2/SDL_video.h>
 #include <stdexcept>
 
+#if defined(SPELUNKY_PSP_WITH_IMGUI)
 #include "imgui.h"
 #include "imgui_impl_sdl2.h"
 #include "imgui_impl_opengl2.h"
@@ -37,7 +38,13 @@ namespace {
             ImGui::DestroyContext();
         }
     };
+}
+#else
+struct Imgui { Imgui(SDL_Window *window, void *gl_context) {}};
+#endif
 
+namespace
+{
     std::pair<int, int> query_screen_dimensions() {
         SDL_DisplayMode dm;
         if (SDL_GetDesktopDisplayMode(0, &dm) != 0)

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -12,6 +12,6 @@ add_subdirectory(glad)
 add_subdirectory(cjson)
 add_subdirectory(entt)
 
-if (SPELUNKY_PSP_PLATFORM_DESKTOP)
+if (SPELUNKY_PSP_WITH_IMGUI)
     add_subdirectory(imgui)
 endif()


### PR DESCRIPTION
A helper in the process of game development - many times I was in need of a tool that would:

* ...allow me to spawn any arbitrary NPC, even in main menu - when adding a new NPC type, or item, or a collectible
* ...allow me to edit rooms (tile editor)
* ...allow me to change any main dude properties, that is amount of money, hearts, bombs, ropes, etc.
* ...allow me to change levels - I will need that when developing the jungle levels (levels 4 and 8) to skip the cave levels

And many more.

